### PR TITLE
www/d: hookup functions and route setups

### DIFF
--- a/politeiad/api/v1/v1.go
+++ b/politeiad/api/v1/v1.go
@@ -239,8 +239,8 @@ type NewRecord struct {
 // NewRecordReply returns the CensorshipRecord that is associated with a valid
 // record.  A valid record is not always going to be published.
 type NewRecordReply struct {
-	Response         string           `json:"response"` // Challenge response
-	CensorshipRecord CensorshipRecord `json:"censorshiprecord"`
+	Response         string           `json:"response"`         // Challenge response
+	CensorshipRecord CensorshipRecord `json:"censorshiprecord"` // Censorship record
 }
 
 // GetUnvetted requests an unvetted record from the server.
@@ -319,8 +319,8 @@ type UpdateRecord struct {
 // UpdateRecordReply returns a CensorshipRecord which may or may not have
 // changed.  Metadata only updates do not create a new CensorshipRecord.
 type UpdateRecordReply struct {
-	Response string `json:"response"` // Challenge response
-	Token    string `json:"token"`    // Censorship token
+	Response         string           `json:"response"`         // Challenge response
+	CensorshipRecord CensorshipRecord `json:"censorshiprecord"` // Censorship record
 }
 
 // UpdateVettedMetadata update a vetted metadata.  This is allowed for
@@ -387,11 +387,11 @@ type InventoryByStatus struct {
 // InventoryByStatusReply returns all censorship record tokens by status.
 type InventoryByStatusReply struct {
 	Response          string   `json:"response"`          // Challenge response
-	Unvetted          []string `json:"unvetted"`          // Unvetted censorship tokens
-	IterationUnvetted []string `json:"iterationunvetted"` // Iteration unvetted censorship tokens
-	Vetted            []string `json:"vetted"`            // Vetted censorship tokens
-	Censored          []string `json:"censored"`          // Censored censorship tokens
-	Archived          []string `json:"archived"`          // Archived censorship tokens
+	Unvetted          []string `json:"unvetted"`          // Unvetted tokens
+	IterationUnvetted []string `json:"iterationunvetted"` // Iteration unvetted tokens
+	Vetted            []string `json:"vetted"`            // Vetted tokens
+	Censored          []string `json:"censored"`          // Censored tokens
+	Archived          []string `json:"archived"`          // Archived tokens
 }
 
 // UserErrorReply returns details about an error that occurred while trying to

--- a/politeiad/api/v1/v1.go
+++ b/politeiad/api/v1/v1.go
@@ -21,13 +21,15 @@ type RecordStatusT int
 
 const (
 	// Routes
-	IdentityRoute             = "/v1/identity/"       // Retrieve identity
-	NewRecordRoute            = "/v1/newrecord/"      // New record
-	UpdateUnvettedRoute       = "/v1/updateunvetted/" // Update unvetted record
-	UpdateVettedRoute         = "/v1/updatevetted/"   // Update vetted record
-	UpdateVettedMetadataRoute = "/v1/updatevettedmd/" // Update vetted metadata
-	GetUnvettedRoute          = "/v1/getunvetted/"    // Retrieve unvetted record
-	GetVettedRoute            = "/v1/getvetted/"      // Retrieve vetted record
+	IdentityRoute               = "/v1/identity/"          // Retrieve identity
+	NewRecordRoute              = "/v1/newrecord/"         // New record
+	UpdateUnvettedRoute         = "/v1/updateunvetted/"    // Update unvetted record
+	UpdateVettedRoute           = "/v1/updatevetted/"      // Update vetted record
+	UpdateVettedMetadataRoute   = "/v1/updatevettedmd/"    // Update vetted metadata
+	UpdateUnvettedMetadataRoute = "/v1/updateunvettedmd/"  // Update unvetted metadata
+	GetUnvettedRoute            = "/v1/getunvetted/"       // Retrieve unvetted record
+	GetVettedRoute              = "/v1/getvetted/"         // Retrieve vetted record
+	InventoryByStatusRoute      = "/v1/inventorybystatus/" // Inventory record tokens by status
 
 	// Auth required
 	InventoryRoute         = "/v1/inventory/"                  // Inventory records
@@ -317,8 +319,8 @@ type UpdateRecord struct {
 // UpdateRecordReply returns a CensorshipRecord which may or may not have
 // changed.  Metadata only updates do not create a new CensorshipRecord.
 type UpdateRecordReply struct {
-	// TODO add censorship record
 	Response string `json:"response"` // Challenge response
+	Token    string `json:"token"`    // Censorship token
 }
 
 // UpdateVettedMetadata update a vetted metadata.  This is allowed for
@@ -333,6 +335,19 @@ type UpdateVettedMetadata struct {
 // UpdateVettedMetadataReply returns a response challenge to an
 // UpdateVettedMetadata command.
 type UpdateVettedMetadataReply struct {
+	Response string `json:"response"` // Challenge response
+}
+
+// UpdateUnvettedMetadata update a unvetted metadata.
+type UpdateUnvettedMetadata struct {
+	Challenge   string           `json:"challenge"`   // Random challenge
+	Token       string           `json:"token"`       // Censorship token
+	MDAppend    []MetadataStream `json:"mdappend"`    // Metadata streams to append
+	MDOverwrite []MetadataStream `json:"mdoverwrite"` // Metadata streams to overwrite
+}
+
+// UpdateUnvettedMetadataReply returns a response challenge.
+type UpdateUnvettedMetadataReply struct {
 	Response string `json:"response"` // Challenge response
 }
 
@@ -361,6 +376,22 @@ type InventoryReply struct {
 	Response string   `json:"response"` // Challenge response
 	Vetted   []Record `json:"vetted"`   // Last N vetted records
 	Branches []Record `json:"branches"` // Last N branches (censored, new etc)
+}
+
+// InventoryByStatus requests for the censhorship tokens from all records
+// filtered by their status.
+type InventoryByStatus struct {
+	Challenge string `json:"challenge"` // Random challenge
+}
+
+// InventoryByStatusReply returns all censorship record tokens by status.
+type InventoryByStatusReply struct {
+	Response          string   `json:"response"`          // Challenge response
+	Unvetted          []string `json:"unvetted"`          // Unvetted censorship tokens
+	IterationUnvetted []string `json:"iterationunvetted"` // Iteration unvetted censorship tokens
+	Vetted            []string `json:"vetted"`            // Vetted censorship tokens
+	Censored          []string `json:"censored"`          // Censored censorship tokens
+	Archived          []string `json:"archived"`          // Archived censorship tokens
 }
 
 // UserErrorReply returns details about an error that occurred while trying to

--- a/politeiad/api/v1/v1.go
+++ b/politeiad/api/v1/v1.go
@@ -244,7 +244,6 @@ type NewRecordReply struct {
 }
 
 // GetUnvetted requests an unvetted record from the server.
-// TODO Implement Version. Unvetted didn't previously have a version.
 type GetUnvetted struct {
 	Challenge string `json:"challenge"` // Random challenge
 	Token     string `json:"token"`     // Censorship token

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -854,16 +854,15 @@ func (p *politeia) updateUnvettedMetadata(w http.ResponseWriter, r *http.Request
 				contentErr.ErrorContext)
 			return
 		}
-
 		// Generic internal error.
 		errorCode := time.Now().Unix()
-		log.Errorf("%v Update unvetted metadata error code %v: %v",
+		log.Errorf("%v update unvetted metadata error code %v: %v",
 			remoteAddr(r), errorCode, err)
 		p.respondWithServerError(w, errorCode)
 		return
 	}
 
-	// Reply with challenge response
+	// Prepare reply
 	response := p.identity.SignMessage(challenge)
 	reply := v1.UpdateUnvettedMetadataReply{
 		Response: hex.EncodeToString(response[:]),

--- a/politeiad/politeiad.go
+++ b/politeiad/politeiad.go
@@ -369,6 +369,7 @@ func (p *politeia) updateRecord(w http.ResponseWriter, r *http.Request, vetted b
 	response := p.identity.SignMessage(challenge)
 	reply := v1.UpdateRecordReply{
 		Response: hex.EncodeToString(response[:]),
+		Token:    t.Token,
 	}
 
 	log.Infof("Update %v record %v: token %v", cmd, remoteAddr(r),
@@ -557,6 +558,45 @@ func (p *politeia) inventory(w http.ResponseWriter, r *http.Request) {
 		unvetted = append(unvetted, p.convertBackendRecord(v))
 	}
 	reply.Branches = unvetted
+
+	util.RespondWithJSON(w, http.StatusOK, reply)
+}
+
+func (p *politeia) inventoryByStatus(w http.ResponseWriter, r *http.Request) {
+	var ibs v1.InventoryByStatus
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&ibs); err != nil {
+		p.respondWithUserError(w, v1.ErrorStatusInvalidRequestPayload, nil)
+		return
+	}
+
+	challenge, err := hex.DecodeString(ibs.Challenge)
+	if err != nil || len(challenge) != v1.ChallengeSize {
+		p.respondWithUserError(w, v1.ErrorStatusInvalidChallenge, nil)
+		return
+	}
+
+	ps, err := p.backend.InventoryByStatus()
+	if err != nil {
+		// Generic internal error.
+		errorCode := time.Now().Unix()
+		log.Errorf("%v InventoryByStatus error code %v: %v", remoteAddr(r),
+			errorCode, err)
+
+		p.respondWithServerError(w, errorCode)
+		return
+	}
+
+	// Prepare reply
+	response := p.identity.SignMessage(challenge)
+	reply := v1.InventoryByStatusReply{
+		Response:          hex.EncodeToString(response[:]),
+		Unvetted:          ps.Unvetted,
+		IterationUnvetted: ps.IterationUnvetted,
+		Vetted:            ps.Vetted,
+		Censored:          ps.Censored,
+		Archived:          ps.Archived,
+	}
 
 	util.RespondWithJSON(w, http.StatusOK, reply)
 }
@@ -768,6 +808,68 @@ func (p *politeia) updateVettedMetadata(w http.ResponseWriter, r *http.Request) 
 	}
 
 	log.Infof("Update vetted metadata %v: token %x", remoteAddr(r), token)
+
+	util.RespondWithJSON(w, http.StatusOK, reply)
+}
+
+func (p *politeia) updateUnvettedMetadata(w http.ResponseWriter, r *http.Request) {
+	var t v1.UpdateUnvettedMetadata
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&t); err != nil {
+		p.respondWithUserError(w, v1.ErrorStatusInvalidRequestPayload, nil)
+		return
+	}
+
+	challenge, err := hex.DecodeString(t.Challenge)
+	if err != nil || len(challenge) != v1.ChallengeSize {
+		p.respondWithUserError(w, v1.ErrorStatusInvalidChallenge, nil)
+		return
+	}
+
+	token, err := util.ConvertStringToken(t.Token)
+	if err != nil {
+		p.respondWithUserError(w, v1.ErrorStatusInvalidRequestPayload, nil)
+		return
+	}
+
+	log.Infof("Update unvetted metadata submitted %v: %x", remoteAddr(r),
+		token)
+
+	err = p.backend.UpdateUnvettedMetadata(token,
+		convertFrontendMetadataStream(t.MDAppend),
+		convertFrontendMetadataStream(t.MDOverwrite))
+	if err != nil {
+		// Reply with error if there were no changes
+		if err == backend.ErrNoChanges {
+			log.Errorf("%v update unvetted metadata no changes: %x",
+				remoteAddr(r), token)
+			p.respondWithUserError(w, v1.ErrorStatusNoChanges, nil)
+			return
+		}
+		// Check for content error.
+		if contentErr, ok := err.(backend.ContentVerificationError); ok {
+			log.Errorf("%v update unvetted metadata content error: %v",
+				remoteAddr(r), contentErr)
+			p.respondWithUserError(w, contentErr.ErrorCode,
+				contentErr.ErrorContext)
+			return
+		}
+
+		// Generic internal error.
+		errorCode := time.Now().Unix()
+		log.Errorf("%v Update unvetted metadata error code %v: %v",
+			remoteAddr(r), errorCode, err)
+		p.respondWithServerError(w, errorCode)
+		return
+	}
+
+	// Reply with challenge response
+	response := p.identity.SignMessage(challenge)
+	reply := v1.UpdateUnvettedMetadataReply{
+		Response: hex.EncodeToString(response[:]),
+	}
+
+	log.Infof("Update unvetted metadata %v: token %x", remoteAddr(r), token)
 
 	util.RespondWithJSON(w, http.StatusOK, reply)
 }
@@ -997,6 +1099,8 @@ func _main() error {
 		permissionPublic)
 	p.addRoute(http.MethodPost, v1.GetVettedRoute, p.getVetted,
 		permissionPublic)
+	p.addRoute(http.MethodPost, v1.InventoryByStatusRoute,
+		p.inventoryByStatus, permissionPublic)
 
 	// Routes that require auth
 	p.addRoute(http.MethodPost, v1.InventoryRoute, p.inventory,
@@ -1007,6 +1111,8 @@ func _main() error {
 		p.setVettedStatus, permissionAuth)
 	p.addRoute(http.MethodPost, v1.UpdateVettedMetadataRoute,
 		p.updateVettedMetadata, permissionAuth)
+	p.addRoute(http.MethodPost, v1.UpdateUnvettedMetadataRoute,
+		p.updateUnvettedMetadata, permissionAuth)
 
 	// Setup plugins
 	/*

--- a/politeiawww/plugin.go
+++ b/politeiawww/plugin.go
@@ -73,44 +73,6 @@ func (p *politeiawww) getBestBlock() (uint64, error) {
 	return bestBlock, nil
 }
 
-func (p *politeiawww) pluginInventory() ([]Plugin, error) {
-	// Setup politeiad request
-	challenge, err := util.Random(pd.ChallengeSize)
-	if err != nil {
-		return nil, err
-	}
-
-	pi := pd.PluginInventory{
-		Challenge: hex.EncodeToString(challenge),
-	}
-
-	// Send politeiad request
-	responseBody, err := p.makeRequest(http.MethodPost,
-		pd.PluginInventoryRoute, pi)
-	if err != nil {
-		return nil, fmt.Errorf("makeRequest: %v", err)
-	}
-
-	// Handle response
-	var reply pd.PluginInventoryReply
-	err = json.Unmarshal(responseBody, &reply)
-	if err != nil {
-		return nil, err
-	}
-
-	err = util.VerifyChallenge(p.cfg.Identity, challenge, reply.Response)
-	if err != nil {
-		return nil, err
-	}
-
-	plugins := make([]Plugin, 0, len(reply.Plugins))
-	for _, v := range reply.Plugins {
-		plugins = append(plugins, convertPluginFromPD(v))
-	}
-
-	return plugins, nil
-}
-
 // getPluginInventory obtains the politeiad plugin inventory. If a politeiad
 // connection cannot be made, the call will be retried every 5 seconds for up
 // to 1000 tries.

--- a/politeiawww/politeiad.go
+++ b/politeiawww/politeiad.go
@@ -440,7 +440,7 @@ func (p *politeiawww) inventoryByStatus() (pd.InventoryByStatusReply, error) {
 	return ibsr, nil
 }
 
-// pluginInventory2 requests the plugin inventory from politeiad and returns
+// pluginInventory requests the plugin inventory from politeiad and returns
 // the available plugins slice.
 func (p *politeiawww) pluginInventory() ([]Plugin, error) {
 	// Setup request

--- a/politeiawww/politeiad.go
+++ b/politeiawww/politeiad.go
@@ -15,21 +15,6 @@ import (
 	"github.com/decred/politeia/util"
 )
 
-// TODO politeiad API changes that are needed
-// -The politeiad UpdateRecordReply is suppose to return the censorship record
-//  but it doesn't.
-// -Add an updateUnvettedMetadata route. This has been added to the politeiad
-//  Backend interface, but a corresponding route has not been added yet.
-// -Add a InventoryByStatus route. This has been added to the politeiad
-//  Backend interface, but a corresponding route has not been added yet.
-//
-// TODO add functions to this file for:
-// -setUnvettedStatus
-// -setVettedStatus
-// -updateUnvettedMetadata
-// -updatedVettedMetadata
-// -plugin
-
 // pdErrorReply represents the request body that is returned from politeaid
 // when an error occurs. PluginID will be populated if this is a plugin error.
 type pdErrorReply struct {
@@ -103,6 +88,8 @@ func (p *politeiawww) makeRequest(method string, route string, v interface{}) ([
 	return responseBody, nil
 }
 
+// newRecord creates a record in politeiad. This route returns the censorship
+// record from the new created record.
 func (p *politeiawww) newRecord(metadata []pd.MetadataStream, files []pd.File) (*pd.CensorshipRecord, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
@@ -121,11 +108,14 @@ func (p *politeiawww) newRecord(metadata []pd.MetadataStream, files []pd.File) (
 		return nil, err
 	}
 
+	// Receive reply
 	var nrr pd.NewRecordReply
 	err = json.Unmarshal(resBody, &nrr)
 	if err != nil {
 		return nil, err
 	}
+
+	// Verify challenge
 	err = util.VerifyChallenge(p.cfg.Identity, challenge, nrr.Response)
 	if err != nil {
 		return nil, err
@@ -155,11 +145,15 @@ func (p *politeiawww) updateRecord(route, token string, mdAppend, mdOverwrite []
 	if err != nil {
 		return nil
 	}
+
+	// Receive reply
 	var urr pd.UpdateRecordReply
 	err = json.Unmarshal(resBody, &urr)
 	if err != nil {
 		return err
 	}
+
+	// Verify challenge
 	err = util.VerifyChallenge(p.cfg.Identity, challenge, urr.Response)
 	if err != nil {
 		return err
@@ -180,12 +174,152 @@ func (p *politeiawww) updateVetted(token string, mdAppend, mdOverwrite []pd.Meta
 		mdAppend, mdOverwrite, filesAdd, filesDel)
 }
 
-func (p *politeiawww) setUnvettedStatus(token string, status pd.RecordStatusT, mdAppend, mdOverwrite []pd.MetadataStream) error {
+// updateUnvettedMetadata updates the metadata of a unvetted record in politeiad.
+func (p *politeiawww) updateUnvettedMetadata(token string, mdAppend, mdOverwrite []pd.MetadataStream) error {
+	// Setup request
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return err
+	}
+	uum := pd.UpdateUnvettedMetadata{
+		Challenge:   hex.EncodeToString(challenge),
+		Token:       token,
+		MDAppend:    mdAppend,
+		MDOverwrite: mdOverwrite,
+	}
+
+	// Send request
+	resBody, err := p.makeRequest(http.MethodPost,
+		pd.UpdateUnvettedMetadataRoute, uum)
+	if err != nil {
+		return nil
+	}
+
+	// Receive reply
+	var urr pd.UpdateUnvettedMetadataReply
+	err = json.Unmarshal(resBody, &urr)
+	if err != nil {
+		return err
+	}
+
+	// Verify challenge
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, urr.Response)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
 
+// updateVettedMetadata updates the metadata of a vetted record in politeiad.
+func (p *politeiawww) updateVettedMetadata(token string, mdAppend, mdOverwrite []pd.MetadataStream) error {
+	// Setup request
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return err
+	}
+	uum := pd.UpdateVettedMetadata{
+		Challenge:   hex.EncodeToString(challenge),
+		Token:       token,
+		MDAppend:    mdAppend,
+		MDOverwrite: mdOverwrite,
+	}
+
+	// Send request
+	resBody, err := p.makeRequest(http.MethodPost,
+		pd.UpdateVettedMetadataRoute, uum)
+	if err != nil {
+		return nil
+	}
+
+	// Receive reply
+	var urr pd.UpdateVettedMetadataReply
+	err = json.Unmarshal(resBody, &urr)
+	if err != nil {
+		return err
+	}
+
+	// Verify challenge
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, urr.Response)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setUnvettedStatus sets the status of a unvetted record in politeiad.
+func (p *politeiawww) setUnvettedStatus(token string, status pd.RecordStatusT, mdAppend, mdOverwrite []pd.MetadataStream) error {
+	// Setup request
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return err
+	}
+	suv := pd.SetUnvettedStatus{
+		Challenge:   hex.EncodeToString(challenge),
+		Token:       token,
+		Status:      status,
+		MDAppend:    mdAppend,
+		MDOverwrite: mdOverwrite,
+	}
+
+	// Send request
+	resBody, err := p.makeRequest(http.MethodPost, pd.SetUnvettedStatusRoute,
+		suv)
+	if err != nil {
+		return err
+	}
+
+	// Receive reply
+	var suvr pd.SetUnvettedStatusReply
+	err = json.Unmarshal(resBody, &suvr)
+	if err != nil {
+		return err
+	}
+
+	// Verify challenge
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, suvr.Response)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setVettedStatus sets the status of a vetted record in politeiad.
 func (p *politeiawww) setVettedStatus(token string, status pd.RecordStatusT, mdAppend, mdOverwrite []pd.MetadataStream) error {
+	// Setup request
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return err
+	}
+	svs := pd.SetVettedStatus{
+		Challenge:   hex.EncodeToString(challenge),
+		Token:       token,
+		Status:      status,
+		MDAppend:    mdAppend,
+		MDOverwrite: mdOverwrite,
+	}
+
+	// Send request
+	resBody, err := p.makeRequest(http.MethodPost, pd.SetVettedStatusRoute,
+		svs)
+	if err != nil {
+		return err
+	}
+
+	// Receive reply
+	var svvr pd.SetVettedStatusReply
+	err = json.Unmarshal(resBody, &svvr)
+	if err != nil {
+		return err
+	}
+
+	// Verify challenge
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, svvr.Response)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -208,11 +342,15 @@ func (p *politeiawww) getUnvetted(token, version string) (*pd.Record, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Receive reply
 	var gur pd.GetUnvettedReply
 	err = json.Unmarshal(resBody, &gur)
 	if err != nil {
 		return nil, err
 	}
+
+	// Verify challenge
 	err = util.VerifyChallenge(p.cfg.Identity, challenge, gur.Response)
 	if err != nil {
 		return nil, err
@@ -245,11 +383,15 @@ func (p *politeiawww) getVetted(token, version string) (*pd.Record, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Receive reply
 	var gvr pd.GetVettedReply
 	err = json.Unmarshal(resBody, &gvr)
 	if err != nil {
 		return nil, err
 	}
+
+	// Verify challenge
 	err = util.VerifyChallenge(p.cfg.Identity, challenge, gvr.Response)
 	if err != nil {
 		return nil, err
@@ -258,8 +400,80 @@ func (p *politeiawww) getVetted(token, version string) (*pd.Record, error) {
 	return &gvr.Record, nil
 }
 
-// getVettedLatest returns the latest version of the vvetted record for the
+// getVettedLatest returns the latest version of the vetted record for the
 // provided token.
 func (p *politeiawww) getVettedLatest(token string) (*pd.Record, error) {
 	return p.getVetted(token, "")
+}
+
+// pluginInventory requests the plugin inventory from politeiad and returns
+// the available plugins slice.
+func (p *politeiawww) pluginInventory() ([]pd.Plugin, error) {
+	// Setup request
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+	pi := pd.PluginInventory{
+		Challenge: hex.EncodeToString(challenge),
+	}
+
+	// Send request
+	resBody, err := p.makeRequest(http.MethodPost, pd.PluginInventoryRoute, pc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Receive reply
+	var pir pd.PluginInventoryReply
+	err = json.Unmarshal(resBody, &pir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify challenge
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, pir.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	return pir.Plugins, nil
+}
+
+// pluginCommand fires a plugin command on politeiad and returns the reply 
+// payload.
+func (p *politeiawww) pluginCommand(pluginID, cmd, cmdID, payload string) (payload string, error) {
+	// Setup request
+	challenge, err := util.Random(pd.ChallengeSize)
+	if err != nil {
+		return nil, err
+	}
+	pc := pd.PluginCommand{
+		Challenge: hex.EncodeToString(challenge),
+		ID:        pluginID,
+		Command:   cmd,
+		CommandID: cmdID,
+		Payload:   payload,
+	}
+
+	// Send request
+	resBody, err := p.makeRequest(http.MethodPost, pd.PluginCommandRoute, pc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Receive reply
+	var pcr pd.PluginCommandReply
+	err = json.Unmarshal(resBody, &pcr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify challenge
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, pcr.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	return pcr.Payload, nil
 }

--- a/politeiawww/politeiad.go
+++ b/politeiawww/politeiad.go
@@ -196,14 +196,14 @@ func (p *politeiawww) updateUnvettedMetadata(token string, mdAppend, mdOverwrite
 	}
 
 	// Receive reply
-	var urr pd.UpdateUnvettedMetadataReply
-	err = json.Unmarshal(resBody, &urr)
+	var uumr pd.UpdateUnvettedMetadataReply
+	err = json.Unmarshal(resBody, &uumr)
 	if err != nil {
 		return err
 	}
 
 	// Verify challenge
-	err = util.VerifyChallenge(p.cfg.Identity, challenge, urr.Response)
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, uumr.Response)
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func (p *politeiawww) updateVettedMetadata(token string, mdAppend, mdOverwrite [
 	if err != nil {
 		return err
 	}
-	uum := pd.UpdateVettedMetadata{
+	uvm := pd.UpdateVettedMetadata{
 		Challenge:   hex.EncodeToString(challenge),
 		Token:       token,
 		MDAppend:    mdAppend,
@@ -227,20 +227,20 @@ func (p *politeiawww) updateVettedMetadata(token string, mdAppend, mdOverwrite [
 
 	// Send request
 	resBody, err := p.makeRequest(http.MethodPost,
-		pd.UpdateVettedMetadataRoute, uum)
+		pd.UpdateVettedMetadataRoute, uvm)
 	if err != nil {
 		return nil
 	}
 
 	// Receive reply
-	var urr pd.UpdateVettedMetadataReply
-	err = json.Unmarshal(resBody, &urr)
+	var uvmr pd.UpdateVettedMetadataReply
+	err = json.Unmarshal(resBody, &uvmr)
 	if err != nil {
 		return err
 	}
 
 	// Verify challenge
-	err = util.VerifyChallenge(p.cfg.Identity, challenge, urr.Response)
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, uvmr.Response)
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (p *politeiawww) setUnvettedStatus(token string, status pd.RecordStatusT, m
 	if err != nil {
 		return err
 	}
-	suv := pd.SetUnvettedStatus{
+	sus := pd.SetUnvettedStatus{
 		Challenge:   hex.EncodeToString(challenge),
 		Token:       token,
 		Status:      status,
@@ -265,20 +265,20 @@ func (p *politeiawww) setUnvettedStatus(token string, status pd.RecordStatusT, m
 
 	// Send request
 	resBody, err := p.makeRequest(http.MethodPost, pd.SetUnvettedStatusRoute,
-		suv)
+		sus)
 	if err != nil {
 		return err
 	}
 
 	// Receive reply
-	var suvr pd.SetUnvettedStatusReply
-	err = json.Unmarshal(resBody, &suvr)
+	var susr pd.SetUnvettedStatusReply
+	err = json.Unmarshal(resBody, &susr)
 	if err != nil {
 		return err
 	}
 
 	// Verify challenge
-	err = util.VerifyChallenge(p.cfg.Identity, challenge, suvr.Response)
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, susr.Response)
 	if err != nil {
 		return err
 	}
@@ -309,14 +309,14 @@ func (p *politeiawww) setVettedStatus(token string, status pd.RecordStatusT, mdA
 	}
 
 	// Receive reply
-	var svvr pd.SetVettedStatusReply
-	err = json.Unmarshal(resBody, &svvr)
+	var svsr pd.SetVettedStatusReply
+	err = json.Unmarshal(resBody, &svsr)
 	if err != nil {
 		return err
 	}
 
 	// Verify challenge
-	err = util.VerifyChallenge(p.cfg.Identity, challenge, svvr.Response)
+	err = util.VerifyChallenge(p.cfg.Identity, challenge, svsr.Response)
 	if err != nil {
 		return err
 	}
@@ -442,7 +442,7 @@ func (p *politeiawww) inventoryByStatus() (pd.InventoryByStatusReply, error) {
 
 // pluginInventory2 requests the plugin inventory from politeiad and returns
 // the available plugins slice.
-func (p *politeiawww) pluginInventory2() ([]pd.Plugin, error) {
+func (p *politeiawww) pluginInventory() ([]Plugin, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -471,7 +471,13 @@ func (p *politeiawww) pluginInventory2() ([]pd.Plugin, error) {
 		return nil, err
 	}
 
-	return pir.Plugins, nil
+	// Convert politeiad plugin types
+	plugins := make([]Plugin, 0, len(pir.Plugins))
+	for _, v := range pir.Plugins {
+		plugins = append(plugins, convertPluginFromPD(v))
+	}
+
+	return plugins, nil
 }
 
 // pluginCommand fires a plugin command on politeiad and returns the reply


### PR DESCRIPTION
This diff implements some pending TODOs on `politeiawww/politeiad.go`, mostly hookup functions with politeiad routes, and some route setups on d.

Changes on `politeiad/politeiad`:

- add censorship record token to `UpdateRecordReply`
- add `updateUnvettedMetadata` route setup
- add `InventoryByStatus` route setup

Changes on `politeiawww/politeiad`:

- func `setUnvettedStatus`
- func `setVettedStatus`
- func `updateUnvettedMetadata`
- func `updatedVettedMetadata`
- func `inventoryByStatus`
- func `pluginCommand`
- func `pluginInventory`

