### PR TITLE
politeia: Add inventory by status command

### DIFF
--- a/politeiad/cmd/politeia/README.md
+++ b/politeiad/cmd/politeia/README.md
@@ -209,25 +209,6 @@ Update record: 72fe14a914783eafb78adcbcd405e723c3f55ff475043b0d89b2cf71ffc6a2d4
 
 ## Set vetted status
 
-Metadata can be updated using the arguments:  
-`'appendmetadata[ID]:[metadataJSON]'`  
-`'overwritemetadata[ID]:[metadataJSON]'`  
-
-The token is specified using the argument:  
-`token:[token]`
-
-Metadata provided using the `overwritemetadata` argument does not have to
-already exist.
-```
-$ politeia -v -testnet -rpchost 127.0.0.1 -rpcuser=user -rpcpass=pass updatevettedmd \
-  'appendmetadata12:{"foo":"bar"}' token:9dfe084fccb7f27c0000  
-
-Update vetted metadata: 9dfe084fccb7f27c0000
-  Metadata append   : 12
-```
-
-## Set vetted status
-
 You can update the status of a vetted record using one of the following
 statuses:
 - `censored` - keep the record unvetted and mark as censored.
@@ -239,7 +220,7 @@ validation is done in the backend.
 ```
 $ politeia -v -testnet -rpchost 127.0.0.1 -rpcuser=user -rpcpass=pass setvettedstatus censored 72fe14a914783eafb78adcbcd405e723c3f55ff475043b0d89b2cf71ffc6a2d4 'overwritemetadata12:"zap"'           
 Set record status:
-  Status: censor
+  Status: censored
 ```
 
 ## Proposal inventory by status

--- a/politeiad/cmd/politeia/README.md
+++ b/politeiad/cmd/politeia/README.md
@@ -11,7 +11,8 @@ Available commands:
 `updatevettedmd`  
 `getvetted`  
 `plugin`  
-`plugininventory`  
+`plugininventory`
+`inventory`
 
 ## Obtain politeiad identity
 
@@ -239,4 +240,19 @@ validation is done in the backend.
 $ politeia -v -testnet -rpchost 127.0.0.1 -rpcuser=user -rpcpass=pass setvettedstatus censored 72fe14a914783eafb78adcbcd405e723c3f55ff475043b0d89b2cf71ffc6a2d4 'overwritemetadata12:"zap"'           
 Set record status:
   Status: censor
+```
+
+## Proposal inventory by status
+
+The `inventory` command retrieves the censorship record tokens from all records,
+separated by their status.
+
+```
+$ politeia -v -testnet -rpchost 127.0.0.1 -rpcuser=user -rpcpass=pass inventory
+
+Inventory by status:
+  Unvetted: [tokens...]
+  Vetted  : [tokens...]
+  Censored: [tokens...]
+  Archived: [tokens...]
 ```

--- a/politeiad/cmd/politeia/README.md
+++ b/politeiad/cmd/politeia/README.md
@@ -223,7 +223,7 @@ Set record status:
   Status: censored
 ```
 
-## Proposal inventory by status
+## Inventory by status
 
 The `inventory` command retrieves the censorship record tokens from all records,
 separated by their status.
@@ -232,8 +232,9 @@ separated by their status.
 $ politeia -v -testnet -rpchost 127.0.0.1 -rpcuser=user -rpcpass=pass inventory
 
 Inventory by status:
-  Unvetted: [tokens...]
-  Vetted  : [tokens...]
-  Censored: [tokens...]
-  Archived: [tokens...]
+  Unvetted         : [tokens...]
+  IterationUnvetted: [tokens...]
+  Vetted           : [tokens...]
+  Censored         : [tokens...]
+  Archived         : [tokens...]
 ```

--- a/politeiad/cmd/politeia/politeia.go
+++ b/politeiad/cmd/politeia/politeia.go
@@ -443,12 +443,12 @@ func proposalInventory() error {
 	}
 
 	// Print response to user
-	unvetted := append(ibsr.Unvetted, ibsr.IterationUnvetted...)
 	fmt.Printf("Inventory by status:\n")
-	fmt.Printf("  Unvetted: %v\n", unvetted)
-	fmt.Printf("  Vetted  : %v\n", ibsr.Vetted)
-	fmt.Printf("  Censored: %v\n", ibsr.Censored)
-	fmt.Printf("  Archived: %v\n", ibsr.Archived)
+	fmt.Printf("  Unvetted         : %v\n", ibsr.Unvetted)
+	fmt.Printf("  IterationUnvetted: %v\n", ibsr.IterationUnvetted)
+	fmt.Printf("  Vetted           : %v\n", ibsr.Vetted)
+	fmt.Printf("  Censored         : %v\n", ibsr.Censored)
+	fmt.Printf("  Archived         : %v\n", ibsr.Archived)
 
 	return nil
 }

--- a/politeiad/cmd/politeia/politeia.go
+++ b/politeiad/cmd/politeia/politeia.go
@@ -68,8 +68,8 @@ func usage() {
 		"identity\n")
 	fmt.Fprintf(os.Stderr, "  plugins           - Retrieve plugin "+
 		"inventory\n")
-	fmt.Fprintf(os.Stderr, "  inventory         - Inventory records "+
-		"<vetted count> <branches count>\n")
+	fmt.Fprintf(os.Stderr, "  inventory         - Inventory records by "+
+		"status\n")
 	fmt.Fprintf(os.Stderr, "  new               - Create new record "+
 		"[metadata<id>]... <filename>...\n")
 	fmt.Fprintf(os.Stderr, "  getunvetted       - Retrieve record "+
@@ -375,6 +375,82 @@ func getFile(filename string) (*v1.File, *[sha256.Size]byte, error) {
 	copy(digest32[:], digest)
 
 	return file, &digest32, nil
+}
+
+func proposalInventory() error {
+	// Prepare request
+	challenge, err := util.Random(v1.ChallengeSize)
+	if err != nil {
+		return err
+	}
+
+	ibs, err := json.Marshal(v1.InventoryByStatus{
+		Challenge: hex.EncodeToString(challenge),
+	})
+	if err != nil {
+		return err
+	}
+
+	if *printJson {
+		fmt.Println(string(ibs))
+	}
+
+	// Make request
+	c, err := util.NewClient(verify, *rpccert)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", *rpchost+v1.InventoryByStatusRoute,
+		bytes.NewReader(ibs))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(*rpcuser, *rpcpass)
+	r, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	// Verify status code response
+	if r.StatusCode != http.StatusOK {
+		e, err := getErrorFromResponse(r)
+		if err != nil {
+			return fmt.Errorf("%v", r.Status)
+		}
+		return fmt.Errorf("%v: %v", r.Status, e)
+	}
+
+	bodyBytes := util.ConvertBodyToByteArray(r.Body, *printJson)
+
+	var ibsr v1.InventoryByStatusReply
+	err = json.Unmarshal(bodyBytes, &ibsr)
+	if err != nil {
+		return fmt.Errorf("Could node unmarshal "+
+			"InventoryByStatusReply: %v", err)
+	}
+
+	// Fetch remote identity
+	id, err := identity.LoadPublicIdentity(*identityFilename)
+	if err != nil {
+		return err
+	}
+
+	// Verify challenge
+	err = util.VerifyChallenge(id, challenge, ibsr.Response)
+	if err != nil {
+		return err
+	}
+
+	// Print response to user
+	unvetted := append(ibsr.Unvetted, ibsr.IterationUnvetted...)
+	fmt.Printf("Inventory by status:\n")
+	fmt.Printf("  Unvetted: %v\n", unvetted)
+	fmt.Printf("  Vetted  : %v\n", ibsr.Vetted)
+	fmt.Printf("  Censored: %v\n", ibsr.Censored)
+	fmt.Printf("  Archived: %v\n", ibsr.Archived)
+
+	return nil
 }
 
 func newRecord() error {
@@ -1469,6 +1545,8 @@ func _main() error {
 				return plugin()
 			case "plugininventory":
 				return getPluginInventory()
+			case "inventory":
+				return proposalInventory()
 			default:
 				return fmt.Errorf("invalid action: %v", a)
 			}

--- a/politeiad/cmd/politeia/politeia.go
+++ b/politeiad/cmd/politeia/politeia.go
@@ -377,7 +377,7 @@ func getFile(filename string) (*v1.File, *[sha256.Size]byte, error) {
 	return file, &digest32, nil
 }
 
-func proposalInventory() error {
+func recordInventory() error {
 	// Prepare request
 	challenge, err := util.Random(v1.ChallengeSize)
 	if err != nil {
@@ -1546,7 +1546,7 @@ func _main() error {
 			case "plugininventory":
 				return getPluginInventory()
 			case "inventory":
-				return proposalInventory()
+				return recordInventory()
 			default:
 				return fmt.Errorf("invalid action: %v", a)
 			}


### PR DESCRIPTION
This diff adds the `inventory` command to the `politeia` tool. It retrieves the censorship record tokens from all records separated by their status.