### PR TITLE
piwww: Verify proposals with pi types

### DIFF
--- a/politeiawww/api/www/v1/v1.go
+++ b/politeiawww/api/www/v1/v1.go
@@ -788,7 +788,7 @@ type UserRegistrationPaymentReply struct {
 // server that the user needs in order to purchase paywall credits.
 type UserProposalPaywall struct{}
 
-// UserProposalPaywallReply is used to reply to the ProposalPaywallDetails
+// UserProposalPaywallReply is used to reply to the UserProposalPaywall
 // command.
 type UserProposalPaywallReply struct {
 	CreditPrice        uint64 `json:"creditprice"`        // Cost per proposal credit in atoms

--- a/politeiawww/cmd/piwww/help.go
+++ b/politeiawww/cmd/piwww/help.go
@@ -94,6 +94,8 @@ func (cmd *helpCmd) Execute(args []string) error {
 		fmt.Printf("%s\n", userEmailVerifyHelpMsg)
 	case "userpaymentverify":
 		fmt.Printf("%s\n", userPaymentVerifyHelpMsg)
+	case "userproposalpaywall":
+		fmt.Printf("%s\n", userProposalPaywallHelpMsg)
 	case "usermanage":
 		fmt.Printf("%s\n", shared.UserManageHelpMsg)
 	case "userkeyupdate":
@@ -108,9 +110,6 @@ func (cmd *helpCmd) Execute(args []string) error {
 		fmt.Printf("%s\n", shared.UserPasswordResetHelpMsg)
 	case "users":
 		fmt.Printf("%s\n", shared.UsersHelpMsg)
-
-	case "proposalpaywall":
-		fmt.Printf("%s\n", proposalPaywallHelpMsg)
 
 	// Websocket commands
 	case "subscribe":

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -60,7 +60,7 @@ type piwww struct {
 	UserPaymentsRescan     userPaymentsRescanCmd        `command:"userpaymentsrescan"`
 	UserPendingPayment     userPendingPaymentCmd        `command:"userpendingpayment"`
 	UserDetails            userDetailsCmd               `command:"userdetails"`
-	Users
+	Users                  shared.UsersCmd              `command:"users"`
 
 	// TODO some of the proposal commands use both the --unvetted and
 	// --vetted flags. Let make them all use only the --unvetted flag.

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -87,6 +87,7 @@ type piwww struct {
 	UserEmailVerify        userEmailVerifyCmd           `command:"useremailverify"`
 	UserPaymentVerify      userPaymentVerifyCmd         `command:"userpaymentverify"`
 	UserVerificationResend userVerificationResendCmd    `command:"userverificationresend"`
+	UserProposalPaywall    userProposalPaywallCmd       `command:"userproposalpaywall"`
 	UserManage             shared.UserManageCmd         `command:"usermanage"`
 	UserKeyUpdate          shared.UserKeyUpdateCmd      `command:"userkeyupdate"`
 	UserUsernameChange     shared.UserUsernameChangeCmd `command:"userusernamechange"`
@@ -95,9 +96,6 @@ type piwww struct {
 	UserTOTPSet            shared.UserTOTPSetCmd        `command:"usertotpset"`
 	UserTOTPVerify         shared.UserTOTPVerifyCmd     `command:"usertotpverify"`
 	Users                  shared.UsersCmd              `command:"users"`
-
-	// TODO rename to reflect that its a users route
-	ProposalPaywall proposalPaywallCmd `command:"proposalpaywall"`
 
 	// Websocket commands
 	Subscribe subscribeCmd `command:"subscribe"`

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -43,6 +43,25 @@ type piwww struct {
 	Logout  shared.LogoutCmd  `command:"logout"`
 	Me      shared.MeCmd      `command:"me"`
 
+	// User commands
+	UserNew                userNewCmd                   `command:"usernew"`
+	UserEdit               userEditCmd                  `command:"useredit"`
+	UserManage             shared.UserManageCmd         `command:"usermanage"`
+	UserEmailVerify        userEmailVerifyCmd           `command:"useremailverify"`
+	UserVerificationResend userVerificationResendCmd    `command:"userverificationresend"`
+	UserPasswordReset      shared.UserPasswordResetCmd  `command:"userpasswordreset"`
+	UserPasswordChange     shared.UserPasswordChangeCmd `command:"userpasswordchange"`
+	UserUsernameChange     shared.UserUsernameChangeCmd `command:"userusernamechange"`
+	UserKeyUpdate          shared.UserKeyUpdateCmd      `command:"userkeyupdate"`
+	UserTOTPSet            shared.UserTOTPSetCmd        `command:"usertotpset"`
+	UserTOTPVerify         shared.UserTOTPVerifyCmd     `command:"usertotpverify"`
+	UserProposalPaywall    userProposalPaywallCmd       `command:"userproposalpaywall"`
+	UserPaymentVerify      userPaymentVerifyCmd         `command:"userpaymentverify"`
+	UserPaymentsRescan     userPaymentsRescanCmd        `command:"userpaymentsrescan"`
+	UserPendingPayment     userPendingPaymentCmd        `command:"userpendingpayment"`
+	UserDetails            userDetailsCmd               `command:"userdetails"`
+	Users
+
 	// TODO some of the proposal commands use both the --unvetted and
 	// --vetted flags. Let make them all use only the --unvetted flag.
 	// If --unvetted is not included then its assumed to be a vetted
@@ -71,25 +90,6 @@ type piwww struct {
 	VoteResults     voteResultsCmd     `command:"voteresults"`
 	VoteSummaries   voteSummariesCmd   `command:"votesummaries"`
 	VoteInventory   voteInventoryCmd   `command:"voteinventory"`
-
-	// User commands
-	UserNew                userNewCmd                   `command:"usernew"`
-	UserEdit               userEditCmd                  `command:"useredit"`
-	UserDetails            userDetailsCmd               `command:"userdetails"`
-	UserPaymentsRescan     userPaymentsRescanCmd        `command:"userpaymentsrescan"`
-	UserPendingPayment     userPendingPaymentCmd        `command:"userpendingpayment"`
-	UserEmailVerify        userEmailVerifyCmd           `command:"useremailverify"`
-	UserPaymentVerify      userPaymentVerifyCmd         `command:"userpaymentverify"`
-	UserVerificationResend userVerificationResendCmd    `command:"userverificationresend"`
-	UserProposalPaywall    userProposalPaywallCmd       `command:"userproposalpaywall"`
-	UserManage             shared.UserManageCmd         `command:"usermanage"`
-	UserKeyUpdate          shared.UserKeyUpdateCmd      `command:"userkeyupdate"`
-	UserUsernameChange     shared.UserUsernameChangeCmd `command:"userusernamechange"`
-	UserPasswordChange     shared.UserPasswordChangeCmd `command:"userpasswordchange"`
-	UserPasswordReset      shared.UserPasswordResetCmd  `command:"userpasswordreset"`
-	UserTOTPSet            shared.UserTOTPSetCmd        `command:"usertotpset"`
-	UserTOTPVerify         shared.UserTOTPVerifyCmd     `command:"usertotpverify"`
-	Users                  shared.UsersCmd              `command:"users"`
 
 	// Websocket commands
 	Subscribe subscribeCmd `command:"subscribe"`

--- a/politeiawww/cmd/piwww/piwww.go
+++ b/politeiawww/cmd/piwww/piwww.go
@@ -43,24 +43,6 @@ type piwww struct {
 	Logout  shared.LogoutCmd  `command:"logout"`
 	Me      shared.MeCmd      `command:"me"`
 
-	// User commands
-	UserNew                userNewCmd                   `command:"usernew"`
-	UserEdit               userEditCmd                  `command:"useredit"`
-	UserManage             shared.UserManageCmd         `command:"usermanage"`
-	UserEmailVerify        userEmailVerifyCmd           `command:"useremailverify"`
-	UserVerificationResend userVerificationResendCmd    `command:"userverificationresend"`
-	UserPasswordReset      shared.UserPasswordResetCmd  `command:"userpasswordreset"`
-	UserPasswordChange     shared.UserPasswordChangeCmd `command:"userpasswordchange"`
-	UserUsernameChange     shared.UserUsernameChangeCmd `command:"userusernamechange"`
-	UserKeyUpdate          shared.UserKeyUpdateCmd      `command:"userkeyupdate"`
-	UserTOTPSet            shared.UserTOTPSetCmd        `command:"usertotpset"`
-	UserTOTPVerify         shared.UserTOTPVerifyCmd     `command:"usertotpverify"`
-	UserPaymentVerify      userPaymentVerifyCmd         `command:"userpaymentverify"`
-	UserPaymentsRescan     userPaymentsRescanCmd        `command:"userpaymentsrescan"`
-	UserPendingPayment     userPendingPaymentCmd        `command:"userpendingpayment"`
-	UserDetails            userDetailsCmd               `command:"userdetails"`
-	Users                  shared.UsersCmd              `command:"users"`
-
 	// TODO some of the proposal commands use both the --unvetted and
 	// --vetted flags. Let make them all use only the --unvetted flag.
 	// If --unvetted is not included then its assumed to be a vetted

--- a/politeiawww/cmd/piwww/proposaledit.go
+++ b/politeiawww/cmd/piwww/proposaledit.go
@@ -218,22 +218,23 @@ func (cmd *proposalEditCmd) Execute(args []string) error {
 		return err
 	}
 
-	// TODO add this back in. The www verify functions were moved to
-	// the cmswww batchproposals command since piwww no longer uses the
-	// www types. Create a verifyProposal function for the pi api
-	// proposal.
-	/*
-		// Verify proposal
-		vr, err := client.Version()
-		if err != nil {
-			return err
-		}
-		err = verifyProposal(per.Proposal, vr.PubKey)
-		if err != nil {
-			return fmt.Errorf("unable to verify proposal %v: %v",
-				per.Proposal.CensorshipRecord.Token, err)
-		}
-	*/
+	// Verify proposal
+	vr, err := client.Version()
+	if err != nil {
+		return err
+	}
+	pr := pi.ProposalRecord{
+		Files:            pe.Files,
+		Metadata:         pe.Metadata,
+		PublicKey:        pe.PublicKey,
+		Signature:        pe.Signature,
+		CensorshipRecord: per.CensorshipRecord,
+	}
+	err = verifyProposal(pr, vr.PubKey)
+	if err != nil {
+		return fmt.Errorf("unable to verify proposal %v: %v",
+			pr.CensorshipRecord.Token, err)
+	}
 
 	return nil
 }

--- a/politeiawww/cmd/piwww/proposalnew.go
+++ b/politeiawww/cmd/piwww/proposalnew.go
@@ -178,26 +178,23 @@ func (cmd *proposalNewCmd) Execute(args []string) error {
 		return err
 	}
 
-	// Verify the censorship record
-	/*
-		// TODO implement this using pi types
-		vr, err := client.Version()
-		if err != nil {
-			return err
-		}
-		pr := v1.ProposalRecord{
-			Files:            np.Files,
-			Metadata:         np.Metadata,
-			PublicKey:        np.PublicKey,
-			Signature:        np.Signature,
-			CensorshipRecord: npr.CensorshipRecord,
-		}
-		err = shared.VerifyProposal(pr, vr.PubKey)
-		if err != nil {
-			return fmt.Errorf("unable to verify proposal %v: %v",
-				pr.CensorshipRecord.Token, err)
-		}
-	*/
+	// Verify proposal
+	vr, err := client.Version()
+	if err != nil {
+		return err
+	}
+	pr := pi.ProposalRecord{
+		Files:            pn.Files,
+		Metadata:         pn.Metadata,
+		PublicKey:        pn.PublicKey,
+		Signature:        pn.Signature,
+		CensorshipRecord: pnr.CensorshipRecord,
+	}
+	err = verifyProposal(pr, vr.PubKey)
+	if err != nil {
+		return fmt.Errorf("unable to verify proposal %v: %v",
+			pr.CensorshipRecord.Token, err)
+	}
 
 	return nil
 }

--- a/politeiawww/cmd/piwww/proposals.go
+++ b/politeiawww/cmd/piwww/proposals.go
@@ -78,6 +78,10 @@ func (cmd *proposalsCmd) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
+	err = shared.PrintJSON(reply)
+	if err != nil {
+		return err
+	}
 
 	// Verify proposals
 	vr, err := client.Version()
@@ -90,11 +94,6 @@ func (cmd *proposalsCmd) Execute(args []string) error {
 			return fmt.Errorf("unable to verify proposal %v: %v",
 				p.CensorshipRecord.Token, err)
 		}
-	}
-
-	err = shared.PrintJSON(reply)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/politeiawww/cmd/piwww/proposals.go
+++ b/politeiawww/cmd/piwww/proposals.go
@@ -78,12 +78,24 @@ func (cmd *proposalsCmd) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Verify proposals
+	vr, err := client.Version()
+	if err != nil {
+		return err
+	}
+	for _, p := range reply.Proposals {
+		err = verifyProposal(p, vr.PubKey)
+		if err != nil {
+			return fmt.Errorf("unable to verify proposal %v: %v",
+				p.CensorshipRecord.Token, err)
+		}
+	}
+
 	err = shared.PrintJSON(reply)
 	if err != nil {
 		return err
 	}
-
-	// TODO verify proposals
 
 	return nil
 }

--- a/politeiawww/cmd/piwww/testrun.go
+++ b/politeiawww/cmd/piwww/testrun.go
@@ -244,7 +244,7 @@ func (cmd *testRunCmd) Execute(args []string) error {
 
 		// Purchase proposal credits
 		fmt.Printf("  Proposal paywall details\n")
-		ppdr, err := client.ProposalPaywallDetails()
+		ppdr, err := client.UserProposalPaywall()
 		if err != nil {
 			return err
 		}

--- a/politeiawww/cmd/piwww/userproposalpaywall.go
+++ b/politeiawww/cmd/piwww/userproposalpaywall.go
@@ -6,21 +6,21 @@ package main
 
 import "github.com/decred/politeia/politeiawww/cmd/shared"
 
-// proposalPaywallCmd gets paywall info for the logged in user.
-type proposalPaywallCmd struct{}
+// userProposalPaywallCmd gets paywall info for the logged in user.
+type userProposalPaywallCmd struct{}
 
 // Execute executes the proposal paywall command.
-func (cmd *proposalPaywallCmd) Execute(args []string) error {
-	ppdr, err := client.ProposalPaywallDetails()
+func (cmd *userProposalPaywallCmd) Execute(args []string) error {
+	ppdr, err := client.UserProposalPaywall()
 	if err != nil {
 		return err
 	}
 	return shared.PrintJSON(ppdr)
 }
 
-// proposalPaywallHelpMsg is the output of the help command when
-// 'proposalpaywall' is specified.
-const proposalPaywallHelpMsg = `proposalpaywall	
+// userProposalPaywallHelpMsg is the output of the help command when
+// 'userproposalpaywall' is specified.
+const userProposalPaywallHelpMsg = `userproposalpaywall	
 
 Fetch proposal paywall details.	
 

--- a/politeiawww/cmd/piwww/util.go
+++ b/politeiawww/cmd/piwww/util.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -14,6 +15,7 @@ import (
 	"github.com/decred/politeia/politeiad/api/v1/identity"
 	pi "github.com/decred/politeia/politeiawww/api/pi/v1"
 	utilwww "github.com/decred/politeia/politeiawww/util"
+	"github.com/decred/politeia/util"
 )
 
 // signedMerkleRoot calculates the merkle root of the passed in list of files
@@ -96,4 +98,99 @@ func decodeProposalMetadata(metadata []pi.Metadata) (*pi.ProposalMetadata, error
 		return nil, fmt.Errorf("proposal metadata not found")
 	}
 	return pm, nil
+}
+
+// verifyDigests verifies if the list of files and metadatas have valid
+// digests. It compares digests that came with the file/metadata with
+// digests calculated from their payload.
+func verifyDigests(files []pi.File, md []pi.Metadata) error {
+	// Validate file digests
+	for _, f := range files {
+		b, err := base64.StdEncoding.DecodeString(f.Payload)
+		if err != nil {
+			return fmt.Errorf("file: %v decode payload err %v",
+				f.Name, err)
+		}
+		digest := util.Digest(b)
+		d, ok := util.ConvertDigest(f.Digest)
+		if !ok {
+			return fmt.Errorf("file: %v invalid digest %v",
+				f.Name, f.Digest)
+		}
+		if !bytes.Equal(digest, d[:]) {
+			return fmt.Errorf("file: %v digests do not match",
+				f.Name)
+		}
+	}
+
+	// Validate metadata digests
+	for _, v := range md {
+		b, err := base64.StdEncoding.DecodeString(v.Payload)
+		if err != nil {
+			return fmt.Errorf("metadata: %v decode payload err %v",
+				v.Hint, err)
+		}
+		digest := util.Digest(b)
+		d, ok := util.ConvertDigest(v.Digest)
+		if !ok {
+			return fmt.Errorf("metadata: %v invalid digest %v",
+				v.Hint, v.Digest)
+		}
+		if !bytes.Equal(digest, d[:]) {
+			return fmt.Errorf("metadata: %v digests do not match metadata",
+				v.Hint)
+		}
+	}
+
+	return nil
+}
+
+// verifyProposal verifies the merkle root, author signature and censorship
+// record of a given proposal.
+func verifyProposal(p pi.ProposalRecord, serverPubKey string) error {
+	if len(p.Files) > 0 {
+		// Verify digests
+		err := verifyDigests(p.Files, p.Metadata)
+		if err != nil {
+			return err
+		}
+		// Verify merkle root
+		mr, err := utilwww.MerkleRoot(p.Files, p.Metadata)
+		if err != nil {
+			return err
+		}
+		// Check if merkle roots match
+		if mr != p.CensorshipRecord.Merkle {
+			return fmt.Errorf("merkle roots do not match")
+		}
+	}
+
+	// Verify proposal signature
+	pid, err := util.IdentityFromString(p.PublicKey)
+	if err != nil {
+		return err
+	}
+	sig, err := util.ConvertSignature(p.Signature)
+	if err != nil {
+		return err
+	}
+	if !pid.VerifyMessage([]byte(p.CensorshipRecord.Merkle), sig) {
+		return fmt.Errorf("invalid proposal signature")
+	}
+
+	// Verify censorship record signature
+	id, err := util.IdentityFromString(serverPubKey)
+	if err != nil {
+		return err
+	}
+	s, err := util.ConvertSignature(p.CensorshipRecord.Signature)
+	if err != nil {
+		return err
+	}
+	msg := []byte(p.CensorshipRecord.Merkle + p.CensorshipRecord.Token)
+	if !id.VerifyMessage(msg, s) {
+		return fmt.Errorf("invalid censorship record signature")
+	}
+
+	return nil
 }

--- a/politeiawww/cmd/shared/client.go
+++ b/politeiawww/cmd/shared/client.go
@@ -681,9 +681,9 @@ func (c *Client) VerifyResetPassword(vrp www.VerifyResetPassword) (*www.VerifyRe
 	return &reply, nil
 }
 
-// ProposalPaywallDetails retrieves proposal credit paywall information for the
+// UserProposalPaywall retrieves proposal credit paywall information for the
 // logged in user.
-func (c *Client) ProposalPaywallDetails() (*www.UserProposalPaywallReply, error) {
+func (c *Client) UserProposalPaywall() (*www.UserProposalPaywallReply, error) {
 	responseBody, err := c.makeRequest(http.MethodGet, www.PoliteiaWWWAPIRoute,
 		www.RouteUserProposalPaywall, nil)
 	if err != nil {


### PR DESCRIPTION
Adds `verifyProposal` back to `piwww` commands with `pi` api types. Renames `proposalpaywall` to `userproposalpaywall`.