### PR TITLE
multi: Pass request context for routes that make calls to d

### DIFF
--- a/politeiawww/comments.go
+++ b/politeiawww/comments.go
@@ -5,16 +5,18 @@
 package main
 
 import (
+	"context"
+
 	"github.com/decred/politeia/politeiad/plugins/comments"
 )
 
 // commentsAll returns all comments for the provided record.
-func (p *politeiawww) commentsAll(cp comments.GetAll) (*comments.GetAllReply, error) {
+func (p *politeiawww) commentsAll(ctx context.Context, cp comments.GetAll) (*comments.GetAllReply, error) {
 	b, err := comments.EncodeGetAll(cp)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(comments.ID, comments.CmdGetAll, string(b))
+	r, err := p.pluginCommand(ctx, comments.ID, comments.CmdGetAll, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -26,12 +28,12 @@ func (p *politeiawww) commentsAll(cp comments.GetAll) (*comments.GetAllReply, er
 }
 
 // commentsGet returns the set of comments specified in the comment's id slice.
-func (p *politeiawww) commentsGet(cg comments.Get) (*comments.GetReply, error) {
+func (p *politeiawww) commentsGet(ctx context.Context, cg comments.Get) (*comments.GetReply, error) {
 	b, err := comments.EncodeGet(cg)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(comments.ID, comments.CmdGet, string(b))
+	r, err := p.pluginCommand(ctx, comments.ID, comments.CmdGet, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -43,12 +45,12 @@ func (p *politeiawww) commentsGet(cg comments.Get) (*comments.GetReply, error) {
 }
 
 // commentVotes returns the comment votes that meet the provided criteria.
-func (p *politeiawww) commentVotes(vs comments.Votes) (*comments.VotesReply, error) {
+func (p *politeiawww) commentVotes(ctx context.Context, vs comments.Votes) (*comments.VotesReply, error) {
 	b, err := comments.EncodeVotes(vs)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(comments.ID, comments.CmdVotes, string(b))
+	r, err := p.pluginCommand(ctx, comments.ID, comments.CmdVotes, string(b))
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/decred.go
+++ b/politeiawww/decred.go
@@ -24,9 +24,7 @@ func (p *politeiawww) decredGetComments(ctx context.Context, token string) ([]de
 	}
 
 	// Execute plugin command
-	// TODO FIXME
-	_ = ctx
-	reply, err := p.pluginCommand(decredplugin.ID, decredplugin.CmdGetComments,
+	reply, err := p.pluginCommand(ctx, decredplugin.ID, decredplugin.CmdGetComments,
 		string(payload))
 	if err != nil {
 		return nil, fmt.Errorf("pluginCommand %v %v: %v",
@@ -50,9 +48,7 @@ func (p *politeiawww) decredBestBlock(ctx context.Context) (uint32, error) {
 	}
 
 	// Execute plugin command
-	// TODO FIXME
-	_ = ctx
-	reply, err := p.pluginCommand(decredplugin.ID, decredplugin.CmdBestBlock,
+	reply, err := p.pluginCommand(ctx, decredplugin.ID, decredplugin.CmdBestBlock,
 		string(payload))
 	if err != nil {
 		return 0, fmt.Errorf("pluginCommand %v %v: %v",

--- a/politeiawww/eventmanager.go
+++ b/politeiawww/eventmanager.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"sync"
@@ -283,7 +284,7 @@ func (p *politeiawww) handleEventProposalStatusChange(ch chan interface{}) {
 
 		// Get the proposal author
 		state := convertPropStateFromPropStatus(d.status)
-		pr, err := p.proposalRecordLatest(state, d.token)
+		pr, err := p.proposalRecordLatest(context.Background(), state, d.token)
 		if err != nil {
 			log.Errorf("handleEventProposalStatusChange: proposalRecordLatest "+
 				"%v %v: %v", state, d.token, err)
@@ -379,7 +380,7 @@ func (p *politeiawww) notifyParentAuthorOnComment(d dataProposalComment, proposa
 
 	// Lookup the parent comment author to check if they should receive
 	// a reply notification.
-	parentComment, err := p.commentsGet(comments.Get{
+	parentComment, err := p.commentsGet(context.Background(), comments.Get{
 		State:      convertCommentsStateFromPi(d.state),
 		Token:      d.token,
 		CommentIDs: []uint32{d.parentID},
@@ -431,7 +432,8 @@ func (p *politeiawww) handleEventProposalComment(ch chan interface{}) {
 
 		// Fetch the proposal record here to avoid calling this two times
 		// on the notify functions below
-		pr, err := p.proposalRecordLatest(d.state, d.token)
+		pr, err := p.proposalRecordLatest(context.Background(), d.state,
+			d.token)
 		if err != nil {
 			err = fmt.Errorf("proposalRecordLatest %v %v: %v",
 				d.state, d.token, err)

--- a/politeiawww/pi.go
+++ b/politeiawww/pi.go
@@ -5,16 +5,18 @@
 package main
 
 import (
+	"context"
+
 	piplugin "github.com/decred/politeia/politeiad/plugins/pi"
 )
 
 // piProposals returns the pi plugin data for the provided proposals.
-func (p *politeiawww) piProposals(ps piplugin.Proposals) (*piplugin.ProposalsReply, error) {
+func (p *politeiawww) piProposals(ctx context.Context, ps piplugin.Proposals) (*piplugin.ProposalsReply, error) {
 	b, err := piplugin.EncodeProposals(ps)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(piplugin.ID, piplugin.CmdProposals, string(b))
+	r, err := p.pluginCommand(ctx, piplugin.ID, piplugin.CmdProposals, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -26,12 +28,12 @@ func (p *politeiawww) piProposals(ps piplugin.Proposals) (*piplugin.ProposalsRep
 }
 
 // piCommentNew uses the pi plugin to submit a new comment.
-func (p *politeiawww) piCommentNew(cn piplugin.CommentNew) (*piplugin.CommentNewReply, error) {
+func (p *politeiawww) piCommentNew(ctx context.Context, cn piplugin.CommentNew) (*piplugin.CommentNewReply, error) {
 	b, err := piplugin.EncodeCommentNew(cn)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(piplugin.ID, piplugin.CmdCommentNew, string(b))
+	r, err := p.pluginCommand(ctx, piplugin.ID, piplugin.CmdCommentNew, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -43,12 +45,12 @@ func (p *politeiawww) piCommentNew(cn piplugin.CommentNew) (*piplugin.CommentNew
 }
 
 // piCommentVote uses the pi plugin to vote on a comment.
-func (p *politeiawww) piCommentVote(cvp piplugin.CommentVote) (*piplugin.CommentVoteReply, error) {
+func (p *politeiawww) piCommentVote(ctx context.Context, cvp piplugin.CommentVote) (*piplugin.CommentVoteReply, error) {
 	b, err := piplugin.EncodeCommentVote(cvp)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(piplugin.ID, piplugin.CmdCommentVote, string(b))
+	r, err := p.pluginCommand(ctx, piplugin.ID, piplugin.CmdCommentVote, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -60,12 +62,12 @@ func (p *politeiawww) piCommentVote(cvp piplugin.CommentVote) (*piplugin.Comment
 }
 
 // piCommentCensor uses the pi plugin to censor a proposal comment.
-func (p *politeiawww) piCommentCensor(cc piplugin.CommentCensor) (*piplugin.CommentCensorReply, error) {
+func (p *politeiawww) piCommentCensor(ctx context.Context, cc piplugin.CommentCensor) (*piplugin.CommentCensorReply, error) {
 	b, err := piplugin.EncodeCommentCensor(cc)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(piplugin.ID, piplugin.CmdCommentCensor, string(b))
+	r, err := p.pluginCommand(ctx, piplugin.ID, piplugin.CmdCommentCensor, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -77,8 +79,8 @@ func (p *politeiawww) piCommentCensor(cc piplugin.CommentCensor) (*piplugin.Comm
 }
 
 // piVoteInventory returns the pi plugin vote inventory.
-func (p *politeiawww) piVoteInventory() (*piplugin.VoteInventoryReply, error) {
-	r, err := p.pluginCommand(piplugin.ID, piplugin.CmdVoteInventory, "")
+func (p *politeiawww) piVoteInventory(ctx context.Context) (*piplugin.VoteInventoryReply, error) {
+	r, err := p.pluginCommand(ctx, piplugin.ID, piplugin.CmdVoteInventory, "")
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/plugin.go
+++ b/politeiawww/plugin.go
@@ -62,7 +62,7 @@ func (p *politeiawww) getPluginInventory() ([]plugin, error) {
 			return nil, fmt.Errorf("max retries exceeded")
 		}
 
-		pi, err := p.pluginInventory()
+		pi, err := p.pluginInventory(ctx)
 		if err != nil {
 			log.Infof("cannot get politeiad plugin inventory: %v: retry in %v",
 				err, sleepInterval)

--- a/politeiawww/politeiad.go
+++ b/politeiawww/politeiad.go
@@ -86,7 +86,7 @@ func (p *politeiawww) makeRequest(ctx context.Context, method string, route stri
 
 // newRecord creates a record in politeiad. This route returns the censorship
 // record from the new created record.
-func (p *politeiawww) newRecord(metadata []pd.MetadataStream, files []pd.File) (*pd.CensorshipRecord, error) {
+func (p *politeiawww) newRecord(ctx context.Context, metadata []pd.MetadataStream, files []pd.File) (*pd.CensorshipRecord, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -99,8 +99,6 @@ func (p *politeiawww) newRecord(metadata []pd.MetadataStream, files []pd.File) (
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost, pd.NewRecordRoute, nr)
 	if err != nil {
 		return nil, err
@@ -124,7 +122,7 @@ func (p *politeiawww) newRecord(metadata []pd.MetadataStream, files []pd.File) (
 
 // updateRecord updates a record in politeiad. This can be used to update
 // unvetted or vetted records depending on the route that is provided.
-func (p *politeiawww) updateRecord(route, token string, mdAppend, mdOverwrite []pd.MetadataStream, filesAdd []pd.File, filesDel []string) (*pd.Record, error) {
+func (p *politeiawww) updateRecord(ctx context.Context, route, token string, mdAppend, mdOverwrite []pd.MetadataStream, filesAdd []pd.File, filesDel []string) (*pd.Record, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -139,8 +137,6 @@ func (p *politeiawww) updateRecord(route, token string, mdAppend, mdOverwrite []
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost, route, ur)
 	if err != nil {
 		return nil, err
@@ -163,19 +159,19 @@ func (p *politeiawww) updateRecord(route, token string, mdAppend, mdOverwrite []
 }
 
 // updateUnvetted updates an unvetted record in politeiad.
-func (p *politeiawww) updateUnvetted(token string, mdAppend, mdOverwrite []pd.MetadataStream, filesAdd []pd.File, filesDel []string) (*pd.Record, error) {
-	return p.updateRecord(pd.UpdateUnvettedRoute, token,
+func (p *politeiawww) updateUnvetted(ctx context.Context, token string, mdAppend, mdOverwrite []pd.MetadataStream, filesAdd []pd.File, filesDel []string) (*pd.Record, error) {
+	return p.updateRecord(ctx, pd.UpdateUnvettedRoute, token,
 		mdAppend, mdOverwrite, filesAdd, filesDel)
 }
 
 // updateVetted updates a vetted record in politeiad.
-func (p *politeiawww) updateVetted(token string, mdAppend, mdOverwrite []pd.MetadataStream, filesAdd []pd.File, filesDel []string) (*pd.Record, error) {
-	return p.updateRecord(pd.UpdateVettedRoute, token,
+func (p *politeiawww) updateVetted(ctx context.Context, token string, mdAppend, mdOverwrite []pd.MetadataStream, filesAdd []pd.File, filesDel []string) (*pd.Record, error) {
+	return p.updateRecord(ctx, pd.UpdateVettedRoute, token,
 		mdAppend, mdOverwrite, filesAdd, filesDel)
 }
 
 // updateUnvettedMetadata updates the metadata of a unvetted record in politeiad.
-func (p *politeiawww) updateUnvettedMetadata(token string, mdAppend, mdOverwrite []pd.MetadataStream) error {
+func (p *politeiawww) updateUnvettedMetadata(ctx context.Context, token string, mdAppend, mdOverwrite []pd.MetadataStream) error {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -189,8 +185,6 @@ func (p *politeiawww) updateUnvettedMetadata(token string, mdAppend, mdOverwrite
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.UpdateUnvettedMetadataRoute, uum)
 	if err != nil {
@@ -214,7 +208,7 @@ func (p *politeiawww) updateUnvettedMetadata(token string, mdAppend, mdOverwrite
 }
 
 // updateVettedMetadata updates the metadata of a vetted record in politeiad.
-func (p *politeiawww) updateVettedMetadata(token string, mdAppend, mdOverwrite []pd.MetadataStream) error {
+func (p *politeiawww) updateVettedMetadata(ctx context.Context, token string, mdAppend, mdOverwrite []pd.MetadataStream) error {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -228,8 +222,6 @@ func (p *politeiawww) updateVettedMetadata(token string, mdAppend, mdOverwrite [
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.UpdateVettedMetadataRoute, uvm)
 	if err != nil {
@@ -253,7 +245,7 @@ func (p *politeiawww) updateVettedMetadata(token string, mdAppend, mdOverwrite [
 }
 
 // setUnvettedStatus sets the status of a unvetted record in politeiad.
-func (p *politeiawww) setUnvettedStatus(token string, status pd.RecordStatusT, mdAppend, mdOverwrite []pd.MetadataStream) (*pd.Record, error) {
+func (p *politeiawww) setUnvettedStatus(ctx context.Context, token string, status pd.RecordStatusT, mdAppend, mdOverwrite []pd.MetadataStream) (*pd.Record, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -268,8 +260,6 @@ func (p *politeiawww) setUnvettedStatus(token string, status pd.RecordStatusT, m
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.SetUnvettedStatusRoute, sus)
 	if err != nil {
@@ -293,7 +283,7 @@ func (p *politeiawww) setUnvettedStatus(token string, status pd.RecordStatusT, m
 }
 
 // setVettedStatus sets the status of a vetted record in politeiad.
-func (p *politeiawww) setVettedStatus(token string, status pd.RecordStatusT, mdAppend, mdOverwrite []pd.MetadataStream) (*pd.Record, error) {
+func (p *politeiawww) setVettedStatus(ctx context.Context, token string, status pd.RecordStatusT, mdAppend, mdOverwrite []pd.MetadataStream) (*pd.Record, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -308,8 +298,6 @@ func (p *politeiawww) setVettedStatus(token string, status pd.RecordStatusT, mdA
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.SetVettedStatusRoute, svs)
 	if err != nil {
@@ -333,7 +321,7 @@ func (p *politeiawww) setVettedStatus(token string, status pd.RecordStatusT, mdA
 }
 
 // getUnvetted retrieves an unvetted record from politeiad.
-func (p *politeiawww) getUnvetted(token, version string) (*pd.Record, error) {
+func (p *politeiawww) getUnvetted(ctx context.Context, token, version string) (*pd.Record, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -346,8 +334,6 @@ func (p *politeiawww) getUnvetted(token, version string) (*pd.Record, error) {
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost, pd.GetUnvettedRoute, gu)
 	if err != nil {
 		return nil, err
@@ -371,12 +357,12 @@ func (p *politeiawww) getUnvetted(token, version string) (*pd.Record, error) {
 
 // getUnvettedLatest returns the latest version of the unvetted record for the
 // provided token.
-func (p *politeiawww) getUnvettedLatest(token string) (*pd.Record, error) {
-	return p.getUnvetted(token, "")
+func (p *politeiawww) getUnvettedLatest(ctx context.Context, token string) (*pd.Record, error) {
+	return p.getUnvetted(ctx, token, "")
 }
 
 // getVetted retrieves a vetted record from politeiad.
-func (p *politeiawww) getVetted(token, version string) (*pd.Record, error) {
+func (p *politeiawww) getVetted(ctx context.Context, token, version string) (*pd.Record, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -389,8 +375,6 @@ func (p *politeiawww) getVetted(token, version string) (*pd.Record, error) {
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.GetVettedRoute, gu)
 	if err != nil {
@@ -415,13 +399,13 @@ func (p *politeiawww) getVetted(token, version string) (*pd.Record, error) {
 
 // getVettedLatest returns the latest version of the vetted record for the
 // provided token.
-func (p *politeiawww) getVettedLatest(token string) (*pd.Record, error) {
-	return p.getVetted(token, "")
+func (p *politeiawww) getVettedLatest(ctx context.Context, token string) (*pd.Record, error) {
+	return p.getVetted(ctx, token, "")
 }
 
 // pluginInventory requests the plugin inventory from politeiad and returns
 // inventoryByStatus retrieves the censorship record tokens filtered by status.
-func (p *politeiawww) inventoryByStatus() (*pd.InventoryByStatusReply, error) {
+func (p *politeiawww) inventoryByStatus(ctx context.Context) (*pd.InventoryByStatusReply, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -432,8 +416,6 @@ func (p *politeiawww) inventoryByStatus() (*pd.InventoryByStatusReply, error) {
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.InventoryByStatusRoute, ibs)
 	if err != nil {
@@ -458,7 +440,7 @@ func (p *politeiawww) inventoryByStatus() (*pd.InventoryByStatusReply, error) {
 
 // pluginInventory requests the plugin inventory from politeiad and returns
 // the available plugins slice.
-func (p *politeiawww) pluginInventory() ([]pd.Plugin, error) {
+func (p *politeiawww) pluginInventory(ctx context.Context) ([]pd.Plugin, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -469,8 +451,6 @@ func (p *politeiawww) pluginInventory() ([]pd.Plugin, error) {
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginInventoryRoute, pi)
 	if err != nil {
@@ -495,7 +475,7 @@ func (p *politeiawww) pluginInventory() ([]pd.Plugin, error) {
 
 // pluginCommand fires a plugin command on politeiad and returns the reply
 // payload.
-func (p *politeiawww) pluginCommand(pluginID, cmd, payload string) (string, error) {
+func (p *politeiawww) pluginCommand(ctx context.Context, pluginID, cmd, payload string) (string, error) {
 	// Setup request
 	challenge, err := util.Random(pd.ChallengeSize)
 	if err != nil {
@@ -510,8 +490,6 @@ func (p *politeiawww) pluginCommand(pluginID, cmd, payload string) (string, erro
 	}
 
 	// Send request
-	// TODO FIXME
-	ctx := context.Background()
 	resBody, err := p.makeRequest(ctx, http.MethodPost,
 		pd.PluginCommandRoute, pc)
 	if err != nil {

--- a/politeiawww/politeiawww.go
+++ b/politeiawww/politeiawww.go
@@ -198,7 +198,7 @@ func (p *politeiawww) handleTokenInventory(w http.ResponseWriter, r *http.Reques
 	}
 
 	isAdmin := user != nil && user.Admin
-	reply, err := p.processTokenInventory(isAdmin)
+	reply, err := p.processTokenInventory(r.Context(), isAdmin)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleTokenInventory: processTokenInventory: %v", err)
@@ -235,7 +235,7 @@ func (p *politeiawww) handleProposalDetails(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	reply, err := p.processProposalDetails(pd, user)
+	reply, err := p.processProposalDetails(r.Context(), pd, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleProposalDetails: processProposalDetails %v", err)
@@ -269,7 +269,7 @@ func (p *politeiawww) handleBatchProposals(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	reply, err := p.processBatchProposals(bp, user)
+	reply, err := p.processBatchProposals(r.Context(), bp, user)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleBatchProposals: processBatchProposals %v", err)
@@ -292,7 +292,7 @@ func (p *politeiawww) handleCastVotes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	avr, err := p.processCastVotes(&cv)
+	avr, err := p.processCastVotes(r.Context(), &cv)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleCastVotes: processCastVotes %v", err)
@@ -309,7 +309,7 @@ func (p *politeiawww) handleVoteResultsWWW(w http.ResponseWriter, r *http.Reques
 	pathParams := mux.Vars(r)
 	token := pathParams["token"]
 
-	vrr, err := p.processVoteResultsWWW(token)
+	vrr, err := p.processVoteResultsWWW(r.Context(), token)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleVoteResultsWWW: processVoteResultsWWW %v",
@@ -335,7 +335,7 @@ func (p *politeiawww) handleBatchVoteSummary(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	reply, err := p.processBatchVoteSummary(bvs)
+	reply, err := p.processBatchVoteSummary(r.Context(), bvs)
 	if err != nil {
 		RespondWithError(w, r, 0,
 			"handleBatchVoteSummary: processBatchVoteSummary %v", err)

--- a/politeiawww/proposals.go
+++ b/politeiawww/proposals.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"strconv"
 
@@ -180,10 +181,10 @@ func convertVoteErrorCodeToWWW(errcode ticketvote.VoteErrorT) decredplugin.Error
 	}
 }
 
-func (p *politeiawww) processProposalDetails(pd www.ProposalsDetails, u *user.User) (*www.ProposalDetailsReply, error) {
+func (p *politeiawww) processProposalDetails(ctx context.Context, pd www.ProposalsDetails, u *user.User) (*www.ProposalDetailsReply, error) {
 	log.Tracef("processProposalDetails: %v", pd.Token)
 
-	pr, err := p.proposalRecord(pi.PropStateVetted, pd.Token, pd.Version)
+	pr, err := p.proposalRecord(ctx, pi.PropStateVetted, pd.Token, pd.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +198,7 @@ func (p *politeiawww) processProposalDetails(pd www.ProposalsDetails, u *user.Us
 	}, nil
 }
 
-func (p *politeiawww) processBatchProposals(bp www.BatchProposals, u *user.User) (*www.BatchProposalsReply, error) {
+func (p *politeiawww) processBatchProposals(ctx context.Context, bp www.BatchProposals, u *user.User) (*www.BatchProposalsReply, error) {
 	log.Tracef("processBatchProposals: %v", bp.Tokens)
 
 	// Setup requests
@@ -209,7 +210,7 @@ func (p *politeiawww) processBatchProposals(bp www.BatchProposals, u *user.User)
 	}
 
 	// Get proposals
-	props, err := p.proposalRecords(pi.PropStateVetted, prs, false)
+	props, err := p.proposalRecords(ctx, pi.PropStateVetted, prs, false)
 	if err != nil {
 		return nil, err
 	}
@@ -229,11 +230,11 @@ func (p *politeiawww) processBatchProposals(bp www.BatchProposals, u *user.User)
 	}, nil
 }
 
-func (p *politeiawww) processVoteResultsWWW(token string) (*www.VoteResultsReply, error) {
+func (p *politeiawww) processVoteResultsWWW(ctx context.Context, token string) (*www.VoteResultsReply, error) {
 	log.Tracef("processVoteResultsWWW: %v", token)
 
 	// Get vote details
-	vd, err := p.voteDetails([]string{token})
+	vd, err := p.voteDetails(ctx, []string{token})
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +258,7 @@ func (p *politeiawww) processVoteResultsWWW(token string) (*www.VoteResultsReply
 	}
 
 	// Get cast votes
-	cv, err := p.castVotes(token)
+	cv, err := p.castVotes(ctx, token)
 	if err != nil {
 		return nil, err
 	}
@@ -296,11 +297,11 @@ func (p *politeiawww) processVoteResultsWWW(token string) (*www.VoteResultsReply
 	}, nil
 }
 
-func (p *politeiawww) processBatchVoteSummary(bvs www.BatchVoteSummary) (*www.BatchVoteSummaryReply, error) {
+func (p *politeiawww) processBatchVoteSummary(ctx context.Context, bvs www.BatchVoteSummary) (*www.BatchVoteSummaryReply, error) {
 	log.Tracef("processBatchVoteSummary: %v", bvs.Tokens)
 
 	// Get vote summaries
-	sm, err := p.voteSummaries(bvs.Tokens)
+	sm, err := p.voteSummaries(ctx, bvs.Tokens)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +339,7 @@ func (p *politeiawww) processBatchVoteSummary(bvs www.BatchVoteSummary) (*www.Ba
 	}, nil
 }
 
-func (p *politeiawww) processCastVotes(ballot *www.Ballot) (*www.BallotReply, error) {
+func (p *politeiawww) processCastVotes(ctx context.Context, ballot *www.Ballot) (*www.BallotReply, error) {
 	log.Tracef("processCastVotes")
 
 	// Prepare plugin command
@@ -360,7 +361,7 @@ func (p *politeiawww) processCastVotes(ballot *www.Ballot) (*www.BallotReply, er
 	}
 
 	// Send plugin command
-	r, err := p.pluginCommand(ticketvote.ID, ticketvote.CmdBallot,
+	r, err := p.pluginCommand(ctx, ticketvote.ID, ticketvote.CmdBallot,
 		string(payload))
 	if err != nil {
 		return nil, err
@@ -386,17 +387,17 @@ func (p *politeiawww) processCastVotes(ballot *www.Ballot) (*www.BallotReply, er
 	}, nil
 }
 
-func (p *politeiawww) processTokenInventory(isAdmin bool) (*www.TokenInventoryReply, error) {
+func (p *politeiawww) processTokenInventory(ctx context.Context, isAdmin bool) (*www.TokenInventoryReply, error) {
 	log.Tracef("processTokenInventory")
 
 	// Get record inventory
-	ri, err := p.inventoryByStatus()
+	ri, err := p.inventoryByStatus(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get vote inventory
-	vi, err := p.piVoteInventory()
+	vi, err := p.piVoteInventory(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiawww/ticketvote.go
+++ b/politeiawww/ticketvote.go
@@ -5,16 +5,18 @@
 package main
 
 import (
+	"context"
+
 	ticketvote "github.com/decred/politeia/politeiad/plugins/ticketvote"
 )
 
 // voteAuthorize uses the ticketvote plugin to authorize a vote.
-func (p *politeiawww) voteAuthorize(a ticketvote.Authorize) (*ticketvote.AuthorizeReply, error) {
+func (p *politeiawww) voteAuthorize(ctx context.Context, a ticketvote.Authorize) (*ticketvote.AuthorizeReply, error) {
 	b, err := ticketvote.EncodeAuthorize(a)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(ticketvote.ID, ticketvote.CmdAuthorize, string(b))
+	r, err := p.pluginCommand(ctx, ticketvote.ID, ticketvote.CmdAuthorize, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -26,12 +28,12 @@ func (p *politeiawww) voteAuthorize(a ticketvote.Authorize) (*ticketvote.Authori
 }
 
 // voteStart uses the ticketvote plugin to start a vote.
-func (p *politeiawww) voteStart(s ticketvote.Start) (*ticketvote.StartReply, error) {
+func (p *politeiawww) voteStart(ctx context.Context, s ticketvote.Start) (*ticketvote.StartReply, error) {
 	b, err := ticketvote.EncodeStart(s)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(ticketvote.ID, ticketvote.CmdStart, string(b))
+	r, err := p.pluginCommand(ctx, ticketvote.ID, ticketvote.CmdStart, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -43,12 +45,12 @@ func (p *politeiawww) voteStart(s ticketvote.Start) (*ticketvote.StartReply, err
 }
 
 // voteStartRunoff uses the ticketvote plugin to start a runoff vote.
-func (p *politeiawww) voteStartRunoff(sr ticketvote.StartRunoff) (*ticketvote.StartRunoffReply, error) {
+func (p *politeiawww) voteStartRunoff(ctx context.Context, sr ticketvote.StartRunoff) (*ticketvote.StartRunoffReply, error) {
 	b, err := ticketvote.EncodeStartRunoff(sr)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(ticketvote.ID, ticketvote.CmdStartRunoff,
+	r, err := p.pluginCommand(ctx, ticketvote.ID, ticketvote.CmdStartRunoff,
 		string(b))
 	if err != nil {
 		return nil, err
@@ -61,12 +63,12 @@ func (p *politeiawww) voteStartRunoff(sr ticketvote.StartRunoff) (*ticketvote.St
 }
 
 // voteBallot uses the ticketvote plugin to cast a ballot of votes.
-func (p *politeiawww) voteBallot(tb ticketvote.Ballot) (*ticketvote.BallotReply, error) {
+func (p *politeiawww) voteBallot(ctx context.Context, tb ticketvote.Ballot) (*ticketvote.BallotReply, error) {
 	b, err := ticketvote.EncodeBallot(tb)
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(ticketvote.ID, ticketvote.CmdBallot, string(b))
+	r, err := p.pluginCommand(ctx, ticketvote.ID, ticketvote.CmdBallot, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +80,7 @@ func (p *politeiawww) voteBallot(tb ticketvote.Ballot) (*ticketvote.BallotReply,
 }
 
 // voteDetails uses the ticketvote plugin to fetch the details of a vote.
-func (p *politeiawww) voteDetails(tokens []string) (*ticketvote.DetailsReply, error) {
+func (p *politeiawww) voteDetails(ctx context.Context, tokens []string) (*ticketvote.DetailsReply, error) {
 	d := ticketvote.Details{
 		Tokens: tokens,
 	}
@@ -86,7 +88,7 @@ func (p *politeiawww) voteDetails(tokens []string) (*ticketvote.DetailsReply, er
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(ticketvote.ID, ticketvote.CmdDetails, string(b))
+	r, err := p.pluginCommand(ctx, ticketvote.ID, ticketvote.CmdDetails, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +100,7 @@ func (p *politeiawww) voteDetails(tokens []string) (*ticketvote.DetailsReply, er
 }
 
 // castVotes uses the ticketvote plugin to fetch cast votes for a record.
-func (p *politeiawww) castVotes(token string) (*ticketvote.CastVotesReply, error) {
+func (p *politeiawww) castVotes(ctx context.Context, token string) (*ticketvote.CastVotesReply, error) {
 	cv := ticketvote.CastVotes{
 		Token: token,
 	}
@@ -106,7 +108,7 @@ func (p *politeiawww) castVotes(token string) (*ticketvote.CastVotesReply, error
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(ticketvote.ID, ticketvote.CmdCastVotes, string(b))
+	r, err := p.pluginCommand(ctx, ticketvote.ID, ticketvote.CmdCastVotes, string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +120,7 @@ func (p *politeiawww) castVotes(token string) (*ticketvote.CastVotesReply, error
 }
 
 // voteSummaries uses the ticketvote plugin to fetch vote summaries.
-func (p *politeiawww) voteSummaries(tokens []string) (*ticketvote.SummariesReply, error) {
+func (p *politeiawww) voteSummaries(ctx context.Context, tokens []string) (*ticketvote.SummariesReply, error) {
 	s := ticketvote.Summaries{
 		Tokens: tokens,
 	}
@@ -126,7 +128,7 @@ func (p *politeiawww) voteSummaries(tokens []string) (*ticketvote.SummariesReply
 	if err != nil {
 		return nil, err
 	}
-	r, err := p.pluginCommand(ticketvote.ID, ticketvote.CmdSummaries, string(b))
+	r, err := p.pluginCommand(ctx, ticketvote.ID, ticketvote.CmdSummaries, string(b))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This diff passes down the request context on routes that make calls to politeiad. This is used to cancel the request if the client interrupts the connection.