### PR TITLE
tlogbe: Add testing framework for the tlog backend

### DIFF
--- a/politeiad/backend/tlogbe/testing.go
+++ b/politeiad/backend/tlogbe/testing.go
@@ -2,195 +2,30 @@ package tlogbe
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/decred/dcrd/dcrutil/v3"
 	v1 "github.com/decred/dcrtime/api/v1"
 	"github.com/decred/politeia/politeiad/backend"
 	"github.com/decred/politeia/politeiad/backend/tlogbe/store/filesystem"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keyspb"
-	"github.com/google/trillian/crypto/sigpb"
-	"github.com/google/trillian/types"
 	"github.com/robfig/cron"
 )
 
 var (
-	_ TClient = (*TestTrillianClient)(nil)
-
 	defaultTestDir     = dcrutil.AppDataDir("politeiadtest", false)
 	defaultTestDataDir = filepath.Join(defaultTestDir, "data")
 )
 
-// TestTrillianClient implements TClient interface and is used for
-// testing purposes.
-type TestTrillianClient struct {
-	sync.RWMutex
-
-	trees  map[int64]*trillian.Tree      // [treeID]Tree
-	leaves map[int64][]*trillian.LogLeaf // [treeID][]LogLeaf
-
-	privateKey *keyspb.PrivateKey
-}
-
-// tree satisfies the TClient interface. Returns trillian tree from passed in
-// ID.
-func (t *TestTrillianClient) tree(treeID int64) (*trillian.Tree, error) {
-	t.RLock()
-	defer t.RUnlock()
-
-	if tree, ok := t.trees[treeID]; ok {
-		return tree, nil
-	}
-
-	return nil, fmt.Errorf("Tree ID not found")
-}
-
-// treesAll satisfies the TClient interface. Signed log roots are not used
-// for testing up until now, so we return a nil value for it.
-func (t *TestTrillianClient) treesAll() ([]*trillian.Tree, error) {
-	t.RLock()
-	defer t.RUnlock()
-
-	trees := make([]*trillian.Tree, len(t.trees))
-	for _, t := range t.trees {
-		trees = append(trees, t)
-	}
-
-	return trees, nil
-}
-
-// treeNew satisfies the TClient interface. Creates a new trillian tree
-// in memory.
-func (t *TestTrillianClient) treeNew() (*trillian.Tree, *trillian.SignedLogRoot, error) {
-	t.Lock()
-	defer t.Unlock()
-
-	// Retrieve private key
-	pk, err := ptypes.MarshalAny(t.privateKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Create trillian tree
-	tree := trillian.Tree{
-		TreeId:             rand.Int63(),
-		TreeState:          trillian.TreeState_ACTIVE,
-		TreeType:           trillian.TreeType_LOG,
-		HashStrategy:       trillian.HashStrategy_RFC6962_SHA256,
-		HashAlgorithm:      sigpb.DigitallySigned_SHA256,
-		SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
-		DisplayName:        "",
-		Description:        "",
-		MaxRootDuration:    ptypes.DurationProto(0),
-		PrivateKey:         pk,
-	}
-	t.trees[tree.TreeId] = &tree
-
-	// Initialize leaves map for that tree
-	t.leaves[tree.TreeId] = []*trillian.LogLeaf{}
-
-	return &tree, nil, nil
-}
-
-// leavesAppend satisfies the TClient interface. It appends leaves to the
-// corresponding trillian tree in memory.
-func (t *TestTrillianClient) leavesAppend(treeID int64, leaves []*trillian.LogLeaf) ([]QueuedLeafProof, *types.LogRootV1, error) {
-	t.Lock()
-	defer t.Unlock()
-
-	// Get last leaf index
-	var index int64
-	if len(t.leaves[treeID]) > 0 {
-		l := len(t.leaves[treeID])
-		index = t.leaves[treeID][l-1].LeafIndex + 1
-	} else {
-		index = 0
-	}
-
-	// Set merkle hash for each leaf and append to memory. Also append the
-	// queued value for the leaves to be returned by the function.
-	var queued []QueuedLeafProof
-	for _, l := range leaves {
-		l.LeafIndex = index
-		l.MerkleLeafHash = MerkleLeafHash(l.LeafValue)
-		t.leaves[treeID] = append(t.leaves[treeID], l)
-
-		queued = append(queued, QueuedLeafProof{
-			QueuedLeaf: &trillian.QueuedLogLeaf{
-				Leaf:   l,
-				Status: nil,
-			},
-			Proof: nil,
-		})
-	}
-
-	return queued, nil, nil
-}
-
-// leavesAll satisfies the TClient interface. Returns all leaves from a
-// trillian tree.
-func (t *TestTrillianClient) leavesAll(treeID int64) ([]*trillian.LogLeaf, error) {
-	t.RLock()
-	defer t.RUnlock()
-
-	// Check if treeID entry exists
-	if _, ok := t.leaves[treeID]; !ok {
-		return nil, fmt.Errorf("Tree ID %d does not contain any leaf data",
-			treeID)
-	}
-
-	return t.leaves[treeID], nil
-}
-
-// leavesByRange satisfies the TClient interface. Returns leaves in range
-// according to the passed in parameters.
-func (t *TestTrillianClient) leavesByRange(treeID, startIndex, count int64) ([]*trillian.LogLeaf, error) {
-	t.RLock()
-	defer t.RUnlock()
-
-	// Check if treeID entry exists
-	if _, ok := t.leaves[treeID]; !ok {
-		return nil, fmt.Errorf("Tree ID %d does not contain any leaf data",
-			treeID)
-	}
-
-	// Get leaves by range. Indexes are ordered.
-	var c int64
-	var leaves []*trillian.LogLeaf
-	for _, leaf := range t.leaves[treeID] {
-		if leaf.LeafIndex >= startIndex && c < count {
-			leaves = append(leaves, leaf)
-			c++
-		}
-	}
-
-	return nil, nil
-}
-
-// signedLogRootForTree is a stub to satisfy the TClient interface. It is not
-// used for testing.
-func (t *TestTrillianClient) signedLogRootForTree(tree *trillian.Tree) (*trillian.SignedLogRoot, *types.LogRootV1, error) {
-	return nil, nil, nil
-}
-
-// close is a stub to satisfy the TClient interface. It is not used for
-// testing.
-func (t *TestTrillianClient) close() {
-	return
-}
-
-// newTestTrillianClient provides a trillian client implementation used for
+// newTestTClient provides a trillian client implementation used for
 // testing. It implements the TClient interface, which includes all major
 // tree operations used in the tlog backend.
-func newTestTrillianClient(t *testing.T) (*TestTrillianClient, error) {
+func newTestTClient(t *testing.T) (*testTClient, error) {
 	// Create trillian private key
 	key, err := keys.NewFromSpec(&keyspb.Specification{
 		Params: &keyspb.Specification_EcdsaParams{},
@@ -203,7 +38,7 @@ func newTestTrillianClient(t *testing.T) (*TestTrillianClient, error) {
 		return nil, err
 	}
 
-	ttc := TestTrillianClient{
+	ttc := testTClient{
 		trees:  make(map[int64]*trillian.Tree),
 		leaves: make(map[int64][]*trillian.LogLeaf),
 		privateKey: &keyspb.PrivateKey{
@@ -224,7 +59,7 @@ func newTestTlog(t *testing.T, id string) (*tlog, error) {
 	}
 	store := filesystem.New(fp)
 
-	tclient, err := newTestTrillianClient(t)
+	tclient, err := newTestTClient(t)
 	if err != nil {
 		return nil, err
 	}

--- a/politeiad/backend/tlogbe/testing.go
+++ b/politeiad/backend/tlogbe/testing.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package tlogbe
 
 import (

--- a/politeiad/backend/tlogbe/testing.go
+++ b/politeiad/backend/tlogbe/testing.go
@@ -1,0 +1,277 @@
+package tlogbe
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/decred/dcrd/dcrutil/v3"
+	v1 "github.com/decred/dcrtime/api/v1"
+	"github.com/decred/politeia/politeiad/backend"
+	"github.com/decred/politeia/politeiad/backend/tlogbe/store/filesystem"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/keys"
+	"github.com/google/trillian/crypto/keys/der"
+	"github.com/google/trillian/crypto/keyspb"
+	"github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/types"
+	"github.com/robfig/cron"
+)
+
+var (
+	_ TClient = (*TestTrillianClient)(nil)
+
+	defaultTestDir     = dcrutil.AppDataDir("politeiadtest", false)
+	defaultTestDataDir = filepath.Join(defaultTestDir, "data")
+)
+
+// TestTrillianClient implements TClient interface and is used for
+// testing purposes.
+type TestTrillianClient struct {
+	sync.RWMutex
+
+	trees  map[int64]*trillian.Tree      // [treeID]Tree
+	leaves map[int64][]*trillian.LogLeaf // [treeID][]LogLeaf
+
+	privateKey *keyspb.PrivateKey
+}
+
+// tree satisfies the TClient interface. Returns trillian tree from passed in
+// ID.
+func (t *TestTrillianClient) tree(treeID int64) (*trillian.Tree, error) {
+	t.RLock()
+	defer t.RUnlock()
+
+	if tree, ok := t.trees[treeID]; ok {
+		return tree, nil
+	}
+
+	return nil, fmt.Errorf("Tree ID not found")
+}
+
+// treesAll satisfies the TClient interface. Signed log roots are not used
+// for testing up until now, so we return a nil value for it.
+func (t *TestTrillianClient) treesAll() ([]*trillian.Tree, error) {
+	t.RLock()
+	defer t.RUnlock()
+
+	trees := make([]*trillian.Tree, len(t.trees))
+	for _, t := range t.trees {
+		trees = append(trees, t)
+	}
+
+	return trees, nil
+}
+
+// treeNew satisfies the TClient interface. Creates a new trillian tree
+// in memory.
+func (t *TestTrillianClient) treeNew() (*trillian.Tree, *trillian.SignedLogRoot, error) {
+	t.Lock()
+	defer t.Unlock()
+
+	// Retrieve private key
+	pk, err := ptypes.MarshalAny(t.privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Create trillian tree
+	tree := trillian.Tree{
+		TreeId:             rand.Int63(),
+		TreeState:          trillian.TreeState_ACTIVE,
+		TreeType:           trillian.TreeType_LOG,
+		HashStrategy:       trillian.HashStrategy_RFC6962_SHA256,
+		HashAlgorithm:      sigpb.DigitallySigned_SHA256,
+		SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
+		DisplayName:        "",
+		Description:        "",
+		MaxRootDuration:    ptypes.DurationProto(0),
+		PrivateKey:         pk,
+	}
+	t.trees[tree.TreeId] = &tree
+
+	// Initialize leaves map for that tree
+	t.leaves[tree.TreeId] = []*trillian.LogLeaf{}
+
+	return &tree, nil, nil
+}
+
+// leavesAppend satisfies the TClient interface. It appends leaves to the
+// corresponding trillian tree in memory.
+func (t *TestTrillianClient) leavesAppend(treeID int64, leaves []*trillian.LogLeaf) ([]QueuedLeafProof, *types.LogRootV1, error) {
+	t.Lock()
+	defer t.Unlock()
+
+	// Get last leaf index
+	var index int64
+	if len(t.leaves[treeID]) > 0 {
+		l := len(t.leaves[treeID])
+		index = t.leaves[treeID][l-1].LeafIndex + 1
+	} else {
+		index = 0
+	}
+
+	// Set merkle hash for each leaf and append to memory. Also append the
+	// queued value for the leaves to be returned by the function.
+	var queued []QueuedLeafProof
+	for _, l := range leaves {
+		l.LeafIndex = index
+		l.MerkleLeafHash = MerkleLeafHash(l.LeafValue)
+		t.leaves[treeID] = append(t.leaves[treeID], l)
+
+		queued = append(queued, QueuedLeafProof{
+			QueuedLeaf: &trillian.QueuedLogLeaf{
+				Leaf:   l,
+				Status: nil,
+			},
+			Proof: nil,
+		})
+	}
+
+	return queued, nil, nil
+}
+
+// leavesAll satisfies the TClient interface. Returns all leaves from a
+// trillian tree.
+func (t *TestTrillianClient) leavesAll(treeID int64) ([]*trillian.LogLeaf, error) {
+	t.RLock()
+	defer t.RUnlock()
+
+	// Check if treeID entry exists
+	if _, ok := t.leaves[treeID]; !ok {
+		return nil, fmt.Errorf("Tree ID %d does not contain any leaf data",
+			treeID)
+	}
+
+	return t.leaves[treeID], nil
+}
+
+// leavesByRange satisfies the TClient interface. Returns leaves in range
+// according to the passed in parameters.
+func (t *TestTrillianClient) leavesByRange(treeID, startIndex, count int64) ([]*trillian.LogLeaf, error) {
+	t.RLock()
+	defer t.RUnlock()
+
+	// Check if treeID entry exists
+	if _, ok := t.leaves[treeID]; !ok {
+		return nil, fmt.Errorf("Tree ID %d does not contain any leaf data",
+			treeID)
+	}
+
+	// Get leaves by range. Indexes are ordered.
+	var c int64
+	var leaves []*trillian.LogLeaf
+	for _, leaf := range t.leaves[treeID] {
+		if leaf.LeafIndex >= startIndex && c < count {
+			leaves = append(leaves, leaf)
+			c++
+		}
+	}
+
+	return nil, nil
+}
+
+// signedLogRootForTree is a stub to satisfy the TClient interface. It is not
+// used for testing.
+func (t *TestTrillianClient) signedLogRootForTree(tree *trillian.Tree) (*trillian.SignedLogRoot, *types.LogRootV1, error) {
+	return nil, nil, nil
+}
+
+// close is a stub to satisfy the TClient interface. It is not used for
+// testing.
+func (t *TestTrillianClient) close() {
+	return
+}
+
+// newTestTrillianClient provides a trillian client implementation used for
+// testing. It implements the TClient interface, which includes all major
+// tree operations used in the tlog backend.
+func newTestTrillianClient(t *testing.T) (*TestTrillianClient, error) {
+	// Create trillian private key
+	key, err := keys.NewFromSpec(&keyspb.Specification{
+		Params: &keyspb.Specification_EcdsaParams{},
+	})
+	if err != nil {
+		return nil, err
+	}
+	keyDer, err := der.MarshalPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	ttc := TestTrillianClient{
+		trees:  make(map[int64]*trillian.Tree),
+		leaves: make(map[int64][]*trillian.LogLeaf),
+		privateKey: &keyspb.PrivateKey{
+			Der: keyDer,
+		},
+	}
+
+	return &ttc, nil
+}
+
+// newTestTlog returns a tlog used for testing.
+func newTestTlog(t *testing.T, id string) (*tlog, error) {
+	// Setup key-value store with test dir
+	fp := filepath.Join(defaultTestDataDir, id)
+	err := os.MkdirAll(fp, 0700)
+	if err != nil {
+		return nil, err
+	}
+	store := filesystem.New(fp)
+
+	tclient, err := newTestTrillianClient(t)
+	if err != nil {
+		return nil, err
+	}
+
+	tlog := tlog{
+		id:            id,
+		dcrtimeHost:   v1.DefaultTestnetTimeHost,
+		encryptionKey: nil,
+		trillian:      tclient,
+		store:         store,
+		cron:          cron.New(),
+	}
+
+	return &tlog, nil
+}
+
+// newTestTlogBackend returns a tlog backend for testing. It wraps
+// tlog and trillian client, providing the framework needed for
+// writing tlog backend tests.
+func newTestTlogBackend(t *testing.T) (*tlogBackend, error) {
+	tlogVetted, err := newTestTlog(t, "vetted")
+	if err != nil {
+		return nil, err
+	}
+	tlogUnvetted, err := newTestTlog(t, "unvetted")
+	if err != nil {
+		return nil, err
+	}
+
+	tlogBackend := tlogBackend{
+		homeDir:       defaultTestDir,
+		dataDir:       defaultTestDataDir,
+		unvetted:      tlogUnvetted,
+		vetted:        tlogVetted,
+		plugins:       make(map[string]plugin),
+		prefixes:      make(map[string][]byte),
+		vettedTreeIDs: make(map[string]int64),
+		inv: recordInventory{
+			unvetted: make(map[backend.MDStatusT][]string),
+			vetted:   make(map[backend.MDStatusT][]string),
+		},
+	}
+
+	err = tlogBackend.setup()
+	if err != nil {
+		return nil, fmt.Errorf("setup: %v", err)
+	}
+
+	return &tlogBackend, nil
+}

--- a/politeiad/backend/tlogbe/tlog.go
+++ b/politeiad/backend/tlogbe/tlog.go
@@ -86,7 +86,7 @@ type tlog struct {
 	id            string
 	dcrtimeHost   string
 	encryptionKey *encryptionKey
-	trillian      TClient
+	trillian      TrillianClient
 	store         store.Blob
 	cron          *cron.Cron
 
@@ -1870,7 +1870,7 @@ func newTlog(id, homeDir, dataDir, trillianHost, trillianKeyFile, dcrtimeHost, e
 	log.Infof("Trillian key %v: %v", id, trillianKeyFile)
 	log.Infof("Trillian host %v: %v", id, trillianHost)
 
-	tclient, err := newTrillianClient(trillianHost, trillianKeyFile)
+	trillianClient, err := newTClient(trillianHost, trillianKeyFile)
 	if err != nil {
 		return nil, err
 	}
@@ -1880,7 +1880,7 @@ func newTlog(id, homeDir, dataDir, trillianHost, trillianKeyFile, dcrtimeHost, e
 		id:            id,
 		dcrtimeHost:   dcrtimeHost,
 		encryptionKey: ek,
-		trillian:      tclient,
+		trillian:      trillianClient,
 		store:         store,
 		cron:          cron.New(),
 	}

--- a/politeiad/backend/tlogbe/tlog.go
+++ b/politeiad/backend/tlogbe/tlog.go
@@ -86,7 +86,7 @@ type tlog struct {
 	id            string
 	dcrtimeHost   string
 	encryptionKey *encryptionKey
-	trillian      *trillianClient
+	trillian      TClient
 	store         store.Blob
 	cron          *cron.Cron
 

--- a/politeiad/backend/tlogbe/tlog.go
+++ b/politeiad/backend/tlogbe/tlog.go
@@ -86,7 +86,7 @@ type tlog struct {
 	id            string
 	dcrtimeHost   string
 	encryptionKey *encryptionKey
-	trillian      TrillianClient
+	trillian      trillianClient
 	store         store.Blob
 	cron          *cron.Cron
 

--- a/politeiad/backend/tlogbe/tlogbe.go
+++ b/politeiad/backend/tlogbe/tlogbe.go
@@ -1779,6 +1779,7 @@ func (t *tlogBackend) Close() {
 	t.vetted.close()
 }
 
+// setup creates the tlog backend in-memory cache.
 func (t *tlogBackend) setup() error {
 	log.Tracef("setup")
 

--- a/politeiad/backend/tlogbe/tlogbe_test.go
+++ b/politeiad/backend/tlogbe/tlogbe_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package tlogbe
 
 import (

--- a/politeiad/backend/tlogbe/tlogbe_test.go
+++ b/politeiad/backend/tlogbe/tlogbe_test.go
@@ -1,0 +1,37 @@
+package tlogbe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/decred/politeia/politeiad/backend"
+)
+
+func TestNewRecord(t *testing.T) {
+	tlogBackend, err := newTestTlogBackend(t)
+	if err != nil {
+		fmt.Printf("Error in newTestTlogBackend %v", err)
+		return
+	}
+
+	metadata := backend.MetadataStream{
+		ID:      1,
+		Payload: "",
+	}
+
+	file := backend.File{
+		Name:    "index.md",
+		MIME:    "text/plain; charset=utf-8",
+		Digest:  "22e88c7d6da9b73fbb515ed6a8f6d133c680527a799e3069ca7ce346d90649b2",
+		Payload: "bW9vCg==",
+	}
+
+	rmd, err := tlogBackend.New([]backend.MetadataStream{metadata}, []backend.File{file})
+	if err != nil {
+		fmt.Printf("Error in New %v", err)
+		return
+	}
+
+	fmt.Println(rmd)
+	fmt.Println(tlogBackend.inv.unvetted)
+}

--- a/politeiad/backend/tlogbe/tlogbe_test.go
+++ b/politeiad/backend/tlogbe/tlogbe_test.go
@@ -33,5 +33,4 @@ func TestNewRecord(t *testing.T) {
 	}
 
 	fmt.Println(rmd)
-	fmt.Println(tlogBackend.inv.unvetted)
 }

--- a/politeiad/backend/tlogbe/trillianclient.go
+++ b/politeiad/backend/tlogbe/trillianclient.go
@@ -35,13 +35,13 @@ import (
 )
 
 var (
-	_ TrillianClient = (*tClient)(nil)
-	_ TrillianClient = (*testTClient)(nil)
+	_ trillianClient = (*tClient)(nil)
+	_ trillianClient = (*testTClient)(nil)
 )
 
-// TrillianClient provides an interface with basic tree operations needed for a
+// trillianClient provides an interface with basic tree operations needed for a
 // trillian client.
-type TrillianClient interface {
+type trillianClient interface {
 	tree(treeID int64) (*trillian.Tree, error)
 
 	treesAll() ([]*trillian.Tree, error)

--- a/politeiad/backend/tlogbe/trillianclient.go
+++ b/politeiad/backend/tlogbe/trillianclient.go
@@ -681,9 +681,7 @@ func (t *testTClient) signedLogRootForTree(tree *trillian.Tree) (*trillian.Signe
 // close is a stub to satisfy the interface. It is not used for testing.
 //
 // This function satisfies the TrillianClient interface.
-func (t *testTClient) close() {
-	return
-}
+func (t *testTClient) close() {}
 
 func newTClient(host, keyFile string) (*tClient, error) {
 	// Setup trillian key file


### PR DESCRIPTION
This PR transforms the trillian client into an Interface, as to allow us to write a test client implementation we can use for testing. This sets the groundwork to allow testing on the `tlogbe` package, and adds an example test for new records.