### PR TITLE
tlogbe: record content tests

### DIFF
--- a/politeiad/backend/tlogbe/testing.go
+++ b/politeiad/backend/tlogbe/testing.go
@@ -5,15 +5,19 @@
 package tlogbe
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"image"
+	"image/jpeg"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/decred/dcrd/dcrutil/v3"
-	v1 "github.com/decred/dcrtime/api/v1"
+	dcrtime "github.com/decred/dcrtime/api/v1"
+	v1 "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/api/v1/mime"
 	"github.com/decred/politeia/politeiad/backend"
 	"github.com/decred/politeia/politeiad/backend/tlogbe/store/filesystem"
@@ -47,6 +51,31 @@ func newBackendFile(t *testing.T, fileName string) backend.File {
 		MIME:    mime.DetectMimeType([]byte(payload)),
 		Digest:  digest,
 		Payload: b64,
+	}
+}
+
+func newBackendFileJPEG(t *testing.T) backend.File {
+	t.Helper()
+
+	b := new(bytes.Buffer)
+	img := image.NewRGBA(image.Rect(0, 0, 1000, 500))
+
+	err := jpeg.Encode(b, img, &jpeg.Options{})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Generate a random name
+	r, err := util.Random(8)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	return backend.File{
+		Name:    hex.EncodeToString(r) + ".jpeg",
+		MIME:    mime.DetectMimeType(b.Bytes()),
+		Digest:  hex.EncodeToString(util.Digest(b.Bytes())),
+		Payload: base64.StdEncoding.EncodeToString(b.Bytes()),
 	}
 }
 
@@ -103,7 +132,7 @@ func newTestTlog(t *testing.T, id string) (*tlog, error) {
 
 	tlog := tlog{
 		id:            id,
-		dcrtimeHost:   v1.DefaultTestnetTimeHost,
+		dcrtimeHost:   dcrtime.DefaultTestnetTimeHost,
 		encryptionKey: nil,
 		trillian:      tclient,
 		store:         store,
@@ -146,4 +175,259 @@ func newTestTlogBackend(t *testing.T) (*tlogBackend, error) {
 	}
 
 	return &tlogBackend, nil
+}
+
+// recordContentTests defines the type used to describe the content
+// verification error tests.
+type recordContentTest struct {
+	description string
+	metadata    []backend.MetadataStream
+	files       []backend.File
+	filesDel    []string
+	err         backend.ContentVerificationError
+}
+
+// setupRecordContentTests returns the list of tests for the verifyContent
+// function. These tests are used on all backend api endpoints that verify
+// content.
+func setupRecordContentTests(t *testing.T) []recordContentTest {
+	t.Helper()
+
+	var rct []recordContentTest
+
+	// Invalid metadata ID error
+	md := []backend.MetadataStream{
+		newBackendMetadataStream(t, v1.MetadataStreamsMax+1, ""),
+	}
+	fs := []backend.File{
+		newBackendFile(t, "index.md"),
+	}
+	fsDel := []string{}
+	err := backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusInvalidMDID,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Invalid metadata ID error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Duplicate metadata ID error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+		newBackendMetadataStream(t, 1, ""),
+	}
+	fs = []backend.File{
+		newBackendFile(t, "index.md"),
+	}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusDuplicateMDID,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Duplicate metadata ID error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Invalid filename error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	fs = []backend.File{
+		newBackendFile(t, "invalid/filename.md"),
+	}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusInvalidFilename,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Invalid filename error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Invalid filename in filesDel error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	fs = []backend.File{
+		newBackendFile(t, "index.md"),
+	}
+	fsDel = []string{"invalid/filename.md"}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusInvalidFilename,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Invalid filename in filesDel error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Empty files error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	fs = []backend.File{}
+	fsDel = []string{}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusEmpty,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Empty files error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Duplicate filename error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	fs = []backend.File{
+		newBackendFile(t, "index.md"),
+		newBackendFile(t, "index.md"),
+	}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusDuplicateFilename,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Duplicate filename error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Duplicate filename in filesDel error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	fs = []backend.File{
+		newBackendFile(t, "index.md"),
+	}
+	fsDel = []string{
+		"duplicate.md",
+		"duplicate.md",
+	}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusDuplicateFilename,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Duplicate filename in filesDel error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Invalid file digest error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	fs = []backend.File{
+		newBackendFile(t, "index.md"),
+	}
+	fsDel = []string{}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusInvalidFileDigest,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Invalid file digest error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Invalid base64 error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	f := newBackendFile(t, "index.md")
+	f.Payload = "*"
+	fs = []backend.File{f}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusInvalidBase64,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Invalid file digest error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Invalid payload digest error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	f = newBackendFile(t, "index.md")
+	f.Payload = "rand"
+	fs = []backend.File{f}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusInvalidFileDigest,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Invalid payload digest error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Invalid MIME type from payload error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	jpeg := newBackendFileJPEG(t)
+	jpeg.Payload = "rand"
+	payload, er := base64.StdEncoding.DecodeString(jpeg.Payload)
+	if er != nil {
+		t.Fatalf(er.Error())
+	}
+	jpeg.Digest = hex.EncodeToString(util.Digest(payload))
+	fs = []backend.File{
+		newBackendFile(t, "index.md"),
+		jpeg,
+	}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusInvalidMIMEType,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Invalid MIME type from payload error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Unsupported MIME type error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	jpeg = newBackendFileJPEG(t)
+	fs = []backend.File{
+		newBackendFile(t, "index.md"),
+		jpeg,
+	}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusUnsupportedMIMEType,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Unsupported MIME type error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	return rct
 }

--- a/politeiad/backend/tlogbe/tlogbe_test.go
+++ b/politeiad/backend/tlogbe/tlogbe_test.go
@@ -5,143 +5,43 @@
 package tlogbe
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
-	v1 "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/backend"
 )
-
-type recordContentTest struct {
-	description string
-	metadata    []backend.MetadataStream
-	files       []backend.File
-	filesDel    []string
-	err         backend.ContentVerificationError
-}
-
-func setupRecordContentTests(t *testing.T) []recordContentTest {
-	t.Helper()
-
-	var rct []recordContentTest
-
-	// Invalid metadata ID error
-	md := []backend.MetadataStream{
-		newBackendMetadataStream(t, v1.MetadataStreamsMax+1, ""),
-	}
-	fs := []backend.File{
-		newBackendFile(t, "index.md"),
-	}
-	fsDel := []string{}
-	err := backend.ContentVerificationError{
-		ErrorCode: v1.ErrorStatusInvalidMDID,
-	}
-	rct = append(rct, recordContentTest{
-		description: "Invalid metadata ID error",
-		metadata:    md,
-		files:       fs,
-		filesDel:    fsDel,
-		err:         err,
-	})
-
-	// Duplicate metadata ID error
-	md = []backend.MetadataStream{
-		newBackendMetadataStream(t, 1, ""),
-		newBackendMetadataStream(t, 1, ""),
-	}
-	fs = []backend.File{
-		newBackendFile(t, "index.md"),
-	}
-	err = backend.ContentVerificationError{
-		ErrorCode: v1.ErrorStatusDuplicateMDID,
-	}
-	rct = append(rct, recordContentTest{
-		description: "Duplicate metadata ID error",
-		metadata:    md,
-		files:       fs,
-		filesDel:    fsDel,
-		err:         err,
-	})
-
-	// Invalid filename error
-	fs = []backend.File{
-		newBackendFile(t, "invalid/filename.md"),
-	}
-	md = []backend.MetadataStream{
-		newBackendMetadataStream(t, 1, ""),
-	}
-	err = backend.ContentVerificationError{
-		ErrorCode: v1.ErrorStatusInvalidFilename,
-	}
-	rct = append(rct, recordContentTest{
-		description: "Invalid filename error",
-		metadata:    md,
-		files:       fs,
-		err:         err,
-	})
-
-	// Empty files error
-	fs = []backend.File{}
-	md = []backend.MetadataStream{
-		newBackendMetadataStream(t, 1, ""),
-	}
-	err = backend.ContentVerificationError{
-		ErrorCode: v1.ErrorStatusEmpty,
-	}
-	rct = append(rct, recordContentTest{
-		description: "Empty files error",
-		metadata:    md,
-		files:       fs,
-		err:         err,
-	})
-
-	// Duplicate filename error
-	fs = []backend.File{
-		newBackendFile(t, "index.md"),
-	}
-	fsDel = []string{}
-	md = []backend.MetadataStream{
-		newBackendMetadataStream(t, 1, ""),
-	}
-	err = backend.ContentVerificationError{
-		ErrorCode: v1.ErrorStatusDuplicateFilename,
-	}
-	rct = append(rct, recordContentTest{
-		description: "Duplicate filename error",
-		metadata:    md,
-		files:       fs,
-		filesDel:    fsDel,
-		err:         err,
-	})
-
-	return rct
-}
 
 func TestNewRecord(t *testing.T) {
 	tlogBackend, err := newTestTlogBackend(t)
 	if err != nil {
-		fmt.Printf("Error in newTestTlogBackend %v", err)
-		return
+		t.Errorf("error in newTestTlogBackend %v", err)
 	}
 
-	metadata := backend.MetadataStream{
-		ID:      1,
-		Payload: "",
+	// Test all record content verification error through the New endpoint
+	recordContentTests := setupRecordContentTests(t)
+	for _, test := range recordContentTests {
+		t.Run(test.description, func(t *testing.T) {
+			_, err := tlogBackend.New(test.metadata, test.files)
+
+			var contentError backend.ContentVerificationError
+			if errors.As(err, &contentError) {
+				if contentError.ErrorCode != test.err.ErrorCode {
+					t.Errorf("got error %v, want %v", contentError.ErrorCode,
+						test.err.ErrorCode)
+				}
+			}
+		})
 	}
 
-	file := backend.File{
-		Name:    "index.md",
-		MIME:    "text/plain; charset=utf-8",
-		Digest:  "22e88c7d6da9b73fbb515ed6a8f6d133c680527a799e3069ca7ce346d90649b2",
-		Payload: "bW9vCg==",
+	// Test success case
+	md := []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
 	}
-
-	rmd, err := tlogBackend.New([]backend.MetadataStream{metadata},
-		[]backend.File{file})
+	fs := []backend.File{
+		newBackendFile(t, "index.md"),
+	}
+	_, err = tlogBackend.New(md, fs)
 	if err != nil {
-		fmt.Printf("Error in New %v", err)
-		return
+		t.Errorf("success case failed with %v", err)
 	}
-
-	fmt.Println(rmd)
 }

--- a/politeiad/backend/tlogbe/tlogbe_test.go
+++ b/politeiad/backend/tlogbe/tlogbe_test.go
@@ -8,8 +8,114 @@ import (
 	"fmt"
 	"testing"
 
+	v1 "github.com/decred/politeia/politeiad/api/v1"
 	"github.com/decred/politeia/politeiad/backend"
 )
+
+type recordContentTest struct {
+	description string
+	metadata    []backend.MetadataStream
+	files       []backend.File
+	filesDel    []string
+	err         backend.ContentVerificationError
+}
+
+func setupRecordContentTests(t *testing.T) []recordContentTest {
+	t.Helper()
+
+	var rct []recordContentTest
+
+	// Invalid metadata ID error
+	md := []backend.MetadataStream{
+		newBackendMetadataStream(t, v1.MetadataStreamsMax+1, ""),
+	}
+	fs := []backend.File{
+		newBackendFile(t, "index.md"),
+	}
+	fsDel := []string{}
+	err := backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusInvalidMDID,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Invalid metadata ID error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Duplicate metadata ID error
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+		newBackendMetadataStream(t, 1, ""),
+	}
+	fs = []backend.File{
+		newBackendFile(t, "index.md"),
+	}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusDuplicateMDID,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Duplicate metadata ID error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	// Invalid filename error
+	fs = []backend.File{
+		newBackendFile(t, "invalid/filename.md"),
+	}
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusInvalidFilename,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Invalid filename error",
+		metadata:    md,
+		files:       fs,
+		err:         err,
+	})
+
+	// Empty files error
+	fs = []backend.File{}
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusEmpty,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Empty files error",
+		metadata:    md,
+		files:       fs,
+		err:         err,
+	})
+
+	// Duplicate filename error
+	fs = []backend.File{
+		newBackendFile(t, "index.md"),
+	}
+	fsDel = []string{}
+	md = []backend.MetadataStream{
+		newBackendMetadataStream(t, 1, ""),
+	}
+	err = backend.ContentVerificationError{
+		ErrorCode: v1.ErrorStatusDuplicateFilename,
+	}
+	rct = append(rct, recordContentTest{
+		description: "Duplicate filename error",
+		metadata:    md,
+		files:       fs,
+		filesDel:    fsDel,
+		err:         err,
+	})
+
+	return rct
+}
 
 func TestNewRecord(t *testing.T) {
 	tlogBackend, err := newTestTlogBackend(t)
@@ -30,7 +136,8 @@ func TestNewRecord(t *testing.T) {
 		Payload: "bW9vCg==",
 	}
 
-	rmd, err := tlogBackend.New([]backend.MetadataStream{metadata}, []backend.File{file})
+	rmd, err := tlogBackend.New([]backend.MetadataStream{metadata},
+		[]backend.File{file})
 	if err != nil {
 		fmt.Printf("Error in New %v", err)
 		return


### PR DESCRIPTION
This diff automates the generation of record content tests to be used throughout the tlogbe endpoints. It also tests them on the `TestRecordNew` while calling the New endpoint

depends on #59 