### PR TITLE
tlogbe: Use proper TempDir for testing data dirs

### DIFF
--- a/politeiad/backend/tlogbe/testing.go
+++ b/politeiad/backend/tlogbe/testing.go
@@ -24,7 +24,7 @@ import (
 	"github.com/decred/politeia/util"
 )
 
-func setupTestDataDir(t *testing.T) (string, string, func(s string)) {
+func setupTestDataDir(t *testing.T) (string, string, func(dir string)) {
 	t.Helper()
 
 	testDir, err := ioutil.TempDir("", "tlog.backend.test")

--- a/politeiad/backend/tlogbe/tlogbe_test.go
+++ b/politeiad/backend/tlogbe/tlogbe_test.go
@@ -14,12 +14,8 @@ import (
 )
 
 func TestNewRecord(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Test all record content verification error through the New endpoint
 	recordContentTests := setupRecordContentTests(t)
@@ -47,19 +43,15 @@ func TestNewRecord(t *testing.T) {
 	fs := []backend.File{
 		newBackendFile(t, "index.md"),
 	}
-	_, err = tlogBackend.New(md, fs)
+	_, err := tlogBackend.New(md, fs)
 	if err != nil {
 		t.Errorf("success case failed with %v", err)
 	}
 }
 
 func TestUpdateUnvettedRecord(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Create new record
 	md := []backend.MetadataStream{
@@ -223,12 +215,8 @@ func TestUpdateUnvettedRecord(t *testing.T) {
 }
 
 func TestUpdateVettedRecord(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Create new record
 	md := []backend.MetadataStream{
@@ -411,12 +399,8 @@ func TestUpdateVettedRecord(t *testing.T) {
 }
 
 func TestUpdateUnvettedMetadata(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Create new record
 	md := []backend.MetadataStream{
@@ -584,12 +568,8 @@ func TestUpdateUnvettedMetadata(t *testing.T) {
 }
 
 func TestUpdateVettedMetadata(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Create new record
 	md := []backend.MetadataStream{
@@ -774,12 +754,8 @@ func TestUpdateVettedMetadata(t *testing.T) {
 }
 
 func TestUnvettedExists(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Create new record
 	md := []backend.MetadataStream{
@@ -815,12 +791,8 @@ func TestUnvettedExists(t *testing.T) {
 }
 
 func TestVettedExists(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Create unvetted record
 	md := []backend.MetadataStream{
@@ -871,12 +843,8 @@ func TestVettedExists(t *testing.T) {
 }
 
 func TestGetUnvetted(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Create new record
 	md := []backend.MetadataStream{
@@ -917,12 +885,8 @@ func TestGetUnvetted(t *testing.T) {
 }
 
 func TestGetVetted(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Create new record
 	md := []backend.MetadataStream{
@@ -971,12 +935,8 @@ func TestGetVetted(t *testing.T) {
 }
 
 func TestSetUnvettedStatus(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Helpers
 	md := []backend.MetadataStream{
@@ -1139,12 +1099,8 @@ func TestSetUnvettedStatus(t *testing.T) {
 }
 
 func TestSetVettedStatus(t *testing.T) {
-	dir, dataDir, cleanup := setupTestDataDir(t)
-	defer cleanup(dir)
-	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
-	if err != nil {
-		t.Error(err)
-	}
+	tlogBackend, cleanup := newTestTlogBackend(t)
+	defer cleanup()
 
 	// Helpers
 	md := []backend.MetadataStream{

--- a/politeiad/backend/tlogbe/tlogbe_test.go
+++ b/politeiad/backend/tlogbe/tlogbe_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestNewRecord(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -52,7 +54,9 @@ func TestNewRecord(t *testing.T) {
 }
 
 func TestUpdateUnvettedRecord(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -219,7 +223,9 @@ func TestUpdateUnvettedRecord(t *testing.T) {
 }
 
 func TestUpdateVettedRecord(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -405,7 +411,9 @@ func TestUpdateVettedRecord(t *testing.T) {
 }
 
 func TestUpdateUnvettedMetadata(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -576,7 +584,9 @@ func TestUpdateUnvettedMetadata(t *testing.T) {
 }
 
 func TestUpdateVettedMetadata(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -764,7 +774,9 @@ func TestUpdateVettedMetadata(t *testing.T) {
 }
 
 func TestUnvettedExists(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -803,7 +815,9 @@ func TestUnvettedExists(t *testing.T) {
 }
 
 func TestVettedExists(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -857,7 +871,9 @@ func TestVettedExists(t *testing.T) {
 }
 
 func TestGetUnvetted(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -901,7 +917,9 @@ func TestGetUnvetted(t *testing.T) {
 }
 
 func TestGetVetted(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -953,7 +971,9 @@ func TestGetVetted(t *testing.T) {
 }
 
 func TestSetUnvettedStatus(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1119,7 +1139,9 @@ func TestSetUnvettedStatus(t *testing.T) {
 }
 
 func TestSetVettedStatus(t *testing.T) {
-	tlogBackend, err := newTestTlogBackend(t)
+	dir, dataDir, cleanup := setupTestDataDir(t)
+	defer cleanup(dir)
+	tlogBackend, err := newTestTlogBackend(t, dir, dataDir)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This diff fixes the temp directories we use for testing the tlog backend.